### PR TITLE
Wrap app with next-auth SessionProvider

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import Providers from '@/components/Providers';
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,9 +30,11 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <Header />
-        <main className="p-4 min-h-screen">{children}</main>
-        <Footer />
+        <Providers>
+          <Header />
+          <main className="p-4 min-h-screen">{children}</main>
+          <Footer />
+        </Providers>
       </body>
     </html>
   );

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { SessionProvider } from 'next-auth/react';
+import type { ReactNode } from 'react';
+
+export default function Providers({ children }: { children: ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}


### PR DESCRIPTION
## Summary
- add Providers component using next-auth's SessionProvider
- wrap layout with Providers so client hooks like useSession work

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68924d4b904c832784f620c4867ece5d