### PR TITLE
Improve letter reveal randomness and scoring tests

### DIFF
--- a/src/lib/scoring.test.ts
+++ b/src/lib/scoring.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { buildMask, revealRandomLetter, calcPoints } from './scoring';
 import { calcXpGain, requiredXp, cefrToNumeric } from './levels';
 
@@ -13,8 +13,20 @@ describe('scoring utils', () => {
     expect(set.size).toBe(1);
   });
 
+  it('revealRandomLetter reveals all instances of a letter', () => {
+    // Force Math.random to pick the first remaining letter
+    const spy = vi.spyOn(Math, 'random').mockReturnValue(0);
+    const set = revealRandomLetter('banana', new Set(['b']));
+    spy.mockRestore();
+    expect(buildMask('banana', set)).toBe('b a _ a _ a');
+  });
+
   it('calcPoints decreases by 10 per letter', () => {
     expect(calcPoints(3)).toBe(70);
+  });
+
+  it('calcPoints has a minimum of 10', () => {
+    expect(calcPoints(15)).toBe(10);
   });
 });
 

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -6,10 +6,14 @@ export function buildMask(word: string, revealed: Set<string>): string {
 }
 
 export function revealRandomLetter(word: string, revealed: Set<string>): Set<string> {
-  const remaining = word
-    .toLowerCase()
-    .split('')
-    .filter((ch) => !revealed.has(ch));
+  const remaining = Array.from(
+    new Set(
+      word
+        .toLowerCase()
+        .split('')
+        .filter((ch) => !revealed.has(ch))
+    )
+  );
   if (remaining.length === 0) return revealed;
   const random = remaining[Math.floor(Math.random() * remaining.length)];
   const updated = new Set(revealed);


### PR DESCRIPTION
## Summary
- ensure random letter reveal selects from unique unrevealed letters
- test duplicate letter revelation and point floor behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892512891a8832791052304e9b517aa