### PR TITLE
feat: add i18n and persist

### DIFF
--- a/next-i18next.config.mjs
+++ b/next-i18next.config.mjs
@@ -1,0 +1,9 @@
+import path from 'path';
+
+export default {
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'tr', 'de', 'es', 'it', 'pt'],
+  },
+  localePath: path.resolve('./src/locales'),
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,8 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
+import nextI18NextConfig from './next-i18next.config.mjs';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  i18n: nextI18NextConfig.i18n,
 };
 
 export default nextConfig;

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,3 +1,4 @@
+'use client';
 import LevelProgress from '@/components/LevelProgress';
 import { useCareerStore } from '@/lib/store';
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,10 +1,15 @@
+'use client';
 import LanguageSelector from './LanguageSelector';
 import Link from 'next/link';
+import { useTranslation } from 'next-i18next';
 
 export default function Header() {
+  const { t } = useTranslation();
   return (
     <header className="flex justify-between items-center p-4 shadow-md">
-      <Link href="/" className="text-2xl font-bold">BulMaze</Link>
+      <Link href="/" className="text-2xl font-bold">
+        {t('title')}
+      </Link>
       <LanguageSelector />
     </header>
   );

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -2,7 +2,21 @@
 
 import { SessionProvider } from 'next-auth/react';
 import type { ReactNode } from 'react';
+import { I18nextProvider } from 'react-i18next';
+import { useEffect } from 'react';
+import i18n from '@/lib/i18n';
+import { useUiStore } from '@/lib/store';
 
 export default function Providers({ children }: { children: ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>;
+  const uiLang = useUiStore((s) => s.uiLang);
+
+  useEffect(() => {
+    i18n.changeLanguage(uiLang);
+  }, [uiLang]);
+
+  return (
+    <SessionProvider>
+      <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+    </SessionProvider>
+  );
 }

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,20 +1,29 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
-import Backend from 'i18next-http-backend';
+import en from '@/locales/en/common.json';
+import tr from '@/locales/tr/common.json';
+import de from '@/locales/de/common.json';
+import es from '@/locales/es/common.json';
+import it from '@/locales/it/common.json';
+import pt from '@/locales/pt/common.json';
 
 export const defaultNS = 'common';
-export const resources = {};
+export const resources = {
+  en: { [defaultNS]: en },
+  tr: { [defaultNS]: tr },
+  de: { [defaultNS]: de },
+  es: { [defaultNS]: es },
+  it: { [defaultNS]: it },
+  pt: { [defaultNS]: pt },
+};
 
 if (!i18n.isInitialized) {
-  i18n
-    .use(Backend)
-    .use(initReactI18next)
-    .init({
-      fallbackLng: 'en',
-      ns: [defaultNS],
-      defaultNS,
-      interpolation: { escapeValue: false },
-    });
+  i18n.use(initReactI18next).init({
+    resources,
+    fallbackLng: 'en',
+    defaultNS,
+    interpolation: { escapeValue: false },
+  });
 }
 
 export default i18n;

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist, createJSONStorage } from 'zustand/middleware';
 import { requiredXp } from './levels';
 
 export interface GameState {
@@ -10,13 +10,26 @@ export interface GameState {
   points: number;
 }
 
-export const useGameStore = create<GameState>(() => ({
-  currentWord: '',
-  hint: '',
-  revealed: new Set(),
-  lettersTaken: 0,
-  points: 100,
-}));
+export const useGameStore = create<GameState>()(
+  persist(
+    (): GameState => ({
+      currentWord: '',
+      hint: '',
+      revealed: new Set(),
+      lettersTaken: 0,
+      points: 100,
+    }),
+    {
+      name: 'game',
+      storage: createJSONStorage(() => localStorage, {
+        replacer: (_key, value) =>
+          value instanceof Set ? Array.from(value) : value,
+        reviver: (key, value) =>
+          key === 'revealed' ? new Set<string>(value as string[]) : value,
+      }),
+    }
+  )
+);
 
 export interface CareerState {
   level: number;
@@ -48,8 +61,13 @@ export interface UiState {
   theme: 'light' | 'dark';
 }
 
-export const useUiStore = create<UiState>(() => ({
-  uiLang: 'en',
-  targetLang: 'en',
-  theme: 'light',
-}));
+export const useUiStore = create<UiState>()(
+  persist(
+    (): UiState => ({
+      uiLang: 'en',
+      targetLang: 'en',
+      theme: 'light',
+    }),
+    { name: 'ui' }
+  )
+);

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -1,0 +1,3 @@
+{
+  "title": "BulMaze"
+}

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -1,0 +1,3 @@
+{
+  "title": "BulMaze"
+}

--- a/src/locales/it/common.json
+++ b/src/locales/it/common.json
@@ -1,0 +1,3 @@
+{
+  "title": "BulMaze"
+}

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -1,0 +1,3 @@
+{
+  "title": "BulMaze"
+}


### PR DESCRIPTION
## Summary
- wire up next-i18next with six languages and header translation
- persist game and UI state using Zustand localStorage

## Testing
- `npm test`
- `npm run lint`
- `OPENAI_API_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68925405a0ac8327bb05a9a853a2e36f