### PR TITLE
feat: add level scoring and store utilities

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -3,10 +3,10 @@ import LevelProgress from '@/components/LevelProgress';
 import { useCareerStore } from '@/lib/store';
 
 export default function ProfilePage() {
-  const { level } = useCareerStore();
+  const { levelNumeric } = useCareerStore();
   return (
     <div className="space-y-4">
-      <h2 className="text-2xl font-bold">Level {level}</h2>
+      <h2 className="text-2xl font-bold">Level {levelNumeric}</h2>
       <LevelProgress />
     </div>
   );

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -1,13 +1,13 @@
 'use client';
 import { useState } from 'react';
 import { useGameStore, useCareerStore } from '@/lib/store';
-import { buildMask, revealRandomLetter, calcPoints } from '@/lib/scoring';
-import { calcXpGain } from '@/lib/levels';
+import { buildMask, revealRandomLetter, calcPoints, calcXpGain } from '@/lib/scoring';
 
 export default function GameBoard({ word, hint }: { word: string; hint: string }) {
   const [input, setInput] = useState('');
   const { revealed, points } = useGameStore();
-  const addXp = useCareerStore((s) => s.addXp);
+  const awardXP = useCareerStore((s) => s.awardXP);
+  const level = useCareerStore.getState().levelNumeric;
 
   const mask = buildMask(word, revealed);
 
@@ -21,8 +21,8 @@ export default function GameBoard({ word, hint }: { word: string; hint: string }
 
   const guess = () => {
     if (input.toLowerCase() === word.toLowerCase()) {
-      const xp = calcXpGain(useCareerStore.getState().level, points);
-      addXp(xp);
+      const xp = calcXpGain(level, points);
+      awardXP(xp);
       alert(`Correct! +${xp} XP`);
     } else {
       alert('Try again');

--- a/src/components/LevelProgress.tsx
+++ b/src/components/LevelProgress.tsx
@@ -1,12 +1,10 @@
 'use client';
 import { motion } from 'framer-motion';
 import { useCareerStore } from '@/lib/store';
-import { requiredXp } from '@/lib/levels';
 
 export default function LevelProgress() {
-  const { level, xp } = useCareerStore();
-  const max = requiredXp(level);
-  const width = (xp / max) * 100;
+  const { xp, requiredXp } = useCareerStore();
+  const width = (xp / requiredXp) * 100;
   return (
     <div className="w-full bg-gray-200 rounded-full h-4">
       <motion.div

--- a/src/lib/levels.ts
+++ b/src/lib/levels.ts
@@ -1,24 +1,32 @@
-export function calcXpGain(level: number, remainingPoints: number): number {
-  const base = 50;
-  const difficultyBonus = level * 5;
-  const performanceBonus = remainingPoints / 5;
-  return Math.round(base + difficultyBonus + performanceBonus);
+export type CEFR = 'A1' | 'A2' | 'B1' | 'B2' | 'C1' | 'C2';
+export type LevelNumeric = 1 | 2 | 3 | 4 | 5 | 6;
+
+const cefrToNumMap: Record<CEFR, LevelNumeric> = {
+  A1: 1,
+  A2: 2,
+  B1: 3,
+  B2: 4,
+  C1: 5,
+  C2: 6,
+};
+
+const numToCefrMap: Record<LevelNumeric, CEFR> = {
+  1: 'A1',
+  2: 'A2',
+  3: 'B1',
+  4: 'B2',
+  5: 'C1',
+  6: 'C2',
+};
+
+export function cefrToNumeric(cefr: CEFR): LevelNumeric {
+  return cefrToNumMap[cefr];
 }
 
-export function requiredXp(level: number): number {
+export function numericToCefr(level: LevelNumeric): CEFR {
+  return numToCefrMap[level];
+}
+
+export function requiredXP(level: LevelNumeric): number {
   return Math.round(300 * Math.pow(level, 1.35));
-}
-
-export function cefrToNumeric(
-  cefr: 'A1' | 'A2' | 'B1' | 'B2' | 'C1' | 'C2'
-): number {
-  const mapping: Record<string, number> = {
-    A1: 1,
-    A2: 2,
-    B1: 3,
-    B2: 4,
-    C1: 5,
-    C2: 6,
-  };
-  return mapping[cefr];
 }

--- a/src/lib/scoring.test.ts
+++ b/src/lib/scoring.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { buildMask, revealRandomLetter, calcPoints } from './scoring';
-import { calcXpGain, requiredXp, cefrToNumeric } from './levels';
+import { buildMask, revealRandomLetter, calcPoints, calcXpGain } from './scoring';
+import { cefrToNumeric, numericToCefr, requiredXP } from './levels';
 
 describe('scoring utils', () => {
   it('buildMask hides unrevealed letters', () => {
@@ -28,18 +28,22 @@ describe('scoring utils', () => {
   it('calcPoints has a minimum of 10', () => {
     expect(calcPoints(15)).toBe(10);
   });
+
+  it('calcXpGain combines level and points', () => {
+    expect(calcXpGain(2, 80)).toBe(76);
+  });
 });
 
 describe('level utils', () => {
-  it('calcXpGain considers level and points', () => {
-    expect(calcXpGain(2, 80)).toBeGreaterThan(0);
-  });
-
-  it('requiredXp grows with level', () => {
-    expect(requiredXp(2)).toBeGreaterThan(requiredXp(1));
+  it('requiredXP grows with level', () => {
+    expect(requiredXP(2)).toBeGreaterThan(requiredXP(1));
   });
 
   it('cefrToNumeric maps correctly', () => {
     expect(cefrToNumeric('B2')).toBe(4);
+  });
+
+  it('numericToCefr maps correctly', () => {
+    expect(numericToCefr(4)).toBe('B2');
   });
 });

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -27,7 +27,9 @@ export function revealRandomLetter(word: string, revealed: Set<string>): Set<str
 }
 
 export function calcPoints(lettersTaken: number): number {
-  const points = 100 - lettersTaken * 10;
-  return points < 10 ? 10 : Math.round(points);
+  return Math.max(10, 100 - lettersTaken * 10);
 }
 
+export function calcXpGain(levelNumeric: number, remainingPoints: number): number {
+  return 50 + levelNumeric * 5 + Math.floor(remainingPoints / 5);
+}


### PR DESCRIPTION
## Summary
- implement CEFR level mapping and XP requirements
- add scoring helpers for word masks, hints, and XP gain
- introduce persistent Zustand stores for UI, game, and career state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68925d43b8a48327952092bf93ea2c2a