### PR TITLE
feat: add AI routes with validation

### DIFF
--- a/src/app/api/ai/evaluate/route.ts
+++ b/src/app/api/ai/evaluate/route.ts
@@ -1,8 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 import { evaluatePlacementAnswers } from '@/lib/ai';
 
+const BodySchema = z.object({ answers: z.any() });
+
 export async function POST(req: NextRequest) {
-  const { answers } = await req.json();
+  const { answers } = BodySchema.parse(await req.json());
   const result = await evaluatePlacementAnswers({ answers });
   return NextResponse.json(result);
 }

--- a/src/app/api/ai/generate/route.ts
+++ b/src/app/api/ai/generate/route.ts
@@ -1,8 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 import { generateWordItem } from '@/lib/ai';
+import { LangSchema } from '@/lib/schemas';
+
+const BodySchema = z.object({
+  targetLang: LangSchema,
+  cefr: z.enum(['A1', 'A2', 'B1', 'B2', 'C1', 'C2']),
+  uiLanguage: LangSchema,
+});
 
 export async function POST(req: NextRequest) {
-  const { targetLang, cefr, uiLang } = await req.json();
-  const item = await generateWordItem({ targetLang, cefr, uiLang });
+  const body = BodySchema.parse(await req.json());
+  const item = await generateWordItem({
+    targetLang: body.targetLang,
+    cefr: body.cefr,
+    uiLang: body.uiLanguage,
+  });
+  if (!item) {
+    return NextResponse.json({ error: 'Invalid response' }, { status: 422 });
+  }
   return NextResponse.json(item);
 }

--- a/src/app/api/ai/placement/route.ts
+++ b/src/app/api/ai/placement/route.ts
@@ -1,8 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 import { generatePlacementTest } from '@/lib/ai';
+import { LangSchema } from '@/lib/schemas';
+
+const BodySchema = z.object({ uiLang: LangSchema });
 
 export async function POST(req: NextRequest) {
-  const { uiLang } = await req.json();
-  const test = await generatePlacementTest({ uiLang });
-  return NextResponse.json(test);
+  const { uiLang } = BodySchema.parse(await req.json());
+  try {
+    const test = await generatePlacementTest({ uiLang });
+    return NextResponse.json(test);
+  } catch {
+    return NextResponse.json({ error: 'Invalid response' }, { status: 422 });
+  }
 }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1,15 +1,20 @@
 import { z } from 'zod';
 
+export const LangSchema = z.enum(['tr', 'en', 'de', 'es', 'it', 'pt']);
+
+export const PosSchema = z.enum(['noun', 'verb', 'adj']);
+
 export const WordItemSchema = z.object({
   word: z.string(),
   hint: z.string(),
   example: z.string(),
   exampleTranslation: z.string(),
-  pos: z.string(),
+  pos: PosSchema,
   difficulty: z.number().int().min(1).max(10),
 });
 
 export type WordItem = z.infer<typeof WordItemSchema>;
+export type Lang = z.infer<typeof LangSchema>;
 
 const PlacementQuestionSchema = z.object({
   question: z.string(),
@@ -28,6 +33,8 @@ export const PlacementResultSchema = z.object({
 export type PlacementResult = z.infer<typeof PlacementResultSchema>;
 
 const schemas = {
+  LangSchema,
+  PosSchema,
   WordItemSchema,
   PlacementTestSchema,
   PlacementResultSchema,


### PR DESCRIPTION
## Summary
- add language and part-of-speech enums for AI response validation
- implement OpenAI helpers with safe prompts, retries, and fallback CEFR evaluation
- expose server-only AI API routes with zod-validated bodies

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689260583bc0832781401273228184fb