### PR TITLE
Add basic navigation and settings skeleton

### DIFF
--- a/src/app/career/page.tsx
+++ b/src/app/career/page.tsx
@@ -2,10 +2,10 @@ import PlacementWizard from '@/components/PlacementWizard';
 import AuthButtons from '@/components/AuthButtons';
 
 export default function CareerPage() {
+  const authEnabled = process.env.FEATURE_AUTH === 'true';
   return (
     <div className="space-y-4">
-      <AuthButtons />
-      <PlacementWizard />
+      {authEnabled ? <AuthButtons /> : <PlacementWizard />}
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,12 @@
 import ModeCards from '@/components/ModeCards';
+import LanguageSelector from '@/components/LanguageSelector';
 
 export default function Home() {
   return (
     <div className="space-y-8">
       <h1 className="text-4xl font-bold text-center">BulMaze</h1>
       <ModeCards />
+      <LanguageSelector />
     </div>
   );
 }

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,13 +1,15 @@
-'use client';
-import LevelProgress from '@/components/LevelProgress';
-import { useCareerStore } from '@/lib/store';
-
 export default function ProfilePage() {
-  const { levelNumeric } = useCareerStore();
   return (
     <div className="space-y-4">
-      <h2 className="text-2xl font-bold">Level {levelNumeric}</h2>
-      <LevelProgress />
+      <h2 className="text-2xl font-bold">Profile</h2>
+      <p>Games Played: 0</p>
+      <p>Total XP: 0</p>
+      <div>
+        <h3 className="text-xl font-semibold">Last 10 Games</h3>
+        <ul className="list-disc pl-6 text-sm">
+          <li>No games played yet</li>
+        </ul>
+      </div>
     </div>
   );
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,10 +1,12 @@
 import LanguageSelector from '@/components/LanguageSelector';
+import ThemeToggle from '@/components/ThemeToggle';
 
 export default function SettingsPage() {
   return (
     <div className="space-y-4">
       <h2 className="text-2xl font-bold">Settings</h2>
       <LanguageSelector />
+      <ThemeToggle />
     </div>
   );
 }

--- a/src/components/AuthButtons.tsx
+++ b/src/components/AuthButtons.tsx
@@ -3,14 +3,31 @@ import { signIn, signOut, useSession } from 'next-auth/react';
 
 export default function AuthButtons() {
   const { data: session } = useSession();
-  if (process.env.FEATURE_AUTH !== 'true') return null;
-  return session ? (
-    <button onClick={() => signOut()} className="px-3 py-1 bg-red-500 text-white rounded">
-      Sign out
-    </button>
-  ) : (
-    <button onClick={() => signIn('google')} className="px-3 py-1 bg-blue-500 text-white rounded">
-      Sign in
-    </button>
+  if (session) {
+    return (
+      <button
+        onClick={() => signOut()}
+        className="px-3 py-1 bg-red-500 text-white rounded"
+      >
+        Sign out
+      </button>
+    );
+  }
+
+  return (
+    <div className="flex gap-2">
+      <button
+        onClick={() => signIn('google')}
+        className="px-3 py-1 bg-blue-500 text-white rounded"
+      >
+        Google
+      </button>
+      <button
+        onClick={() => signIn('apple')}
+        className="px-3 py-1 bg-black text-white rounded"
+      >
+        Apple
+      </button>
+    </div>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,4 @@
 'use client';
-import LanguageSelector from './LanguageSelector';
 import Link from 'next/link';
 import { useTranslation } from 'next-i18next';
 
@@ -10,7 +9,12 @@ export default function Header() {
       <Link href="/" className="text-2xl font-bold">
         {t('title')}
       </Link>
-      <LanguageSelector />
+      <nav className="flex gap-4">
+        <Link href="/quick">Quick</Link>
+        <Link href="/career">Career</Link>
+        <Link href="/profile">Profile</Link>
+        <Link href="/settings">Settings</Link>
+      </nav>
     </header>
   );
 }

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -9,10 +9,15 @@ import { SessionProvider } from 'next-auth/react';
 
 export default function Providers({ children }: { children: ReactNode }) {
   const uiLang = useUiStore((s) => s.uiLang);
+  const theme = useUiStore((s) => s.theme);
 
   useEffect(() => {
     i18n.changeLanguage(uiLang);
   }, [uiLang]);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+  }, [theme]);
 
   if (process.env.FEATURE_AUTH === 'true') {
     return (

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,20 @@
+'use client';
+import { useUiStore } from '@/lib/store';
+import { useEffect } from 'react';
+
+export default function ThemeToggle() {
+  const theme = useUiStore((s) => s.theme);
+  const setTheme = useUiStore((s) => s.setTheme);
+
+  const toggle = () => setTheme(theme === 'light' ? 'dark' : 'light');
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+  }, [theme]);
+
+  return (
+    <button onClick={toggle} className="px-3 py-1 border rounded">
+      {theme === 'light' ? 'Dark' : 'Light'} Mode
+    </button>
+  );
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -15,7 +15,7 @@ export interface UIActions {
   setTheme: (theme: 'light' | 'dark') => void;
 }
 
-export const useUIStore = create<UIState & UIActions>()(
+export const useUiStore = create<UIState & UIActions>()(
   persist(
     (set) => ({
       uiLang: 'en',


### PR DESCRIPTION
## Summary
- add home language selectors with mode cards
- support auth vs placement wizard entry in career mode
- stub profile stats and settings with theme toggle
- wire up header navigation and theme store

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: The OPENAI_API_KEY environment variable is missing or empty)*

------
https://chatgpt.com/codex/tasks/task_e_689262fde2148327ad08d8b12452dc78