### PR TITLE
Integrate game board with store and API

### DIFF
--- a/src/app/quick/page.tsx
+++ b/src/app/quick/page.tsx
@@ -1,10 +1,9 @@
 import GameBoard from '@/components/GameBoard';
 
-// placeholder word and hint
 export default function QuickPage() {
   return (
     <div className="max-w-xl mx-auto">
-      <GameBoard word="example" hint="Sample word" />
+      <GameBoard />
     </div>
   );
 }

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -1,24 +1,54 @@
 'use client';
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import LevelProgress from './LevelProgress';
-import { useGameStore, useCareerStore } from '@/lib/store';
+import WordResultCard from './WordResultCard';
+import { useGameStore, useCareerStore, useUiStore } from '@/lib/store';
 import { buildMask, calcXpGain } from '@/lib/scoring';
+import { cn } from '@/lib/utils';
 
-export interface GameBoardProps {
-  word: string;
-  hint: string;
-}
-
-export default function GameBoard({ word, hint }: GameBoardProps) {
+export default function GameBoard() {
   const [guess, setGuess] = useState('');
+  const [showResult, setShowResult] = useState(false);
+  const [shake, setShake] = useState(false);
+
+  const word = useGameStore((s) => s.word);
+  const hint = useGameStore((s) => s.hint);
+  const example = useGameStore((s) => s.example);
+  const translation = useGameStore((s) => s.exampleTranslation);
   const revealed = useGameStore((s) => s.revealed);
   const points = useGameStore((s) => s.points);
   const takeLetter = useGameStore((s) => s.takeLetter);
   const makeGuess = useGameStore((s) => s.makeGuess);
+  const setWordItem = useGameStore((s) => s.setWordItem);
+
   const awardXP = useCareerStore((s) => s.awardXP);
   const level = useCareerStore((s) => s.levelNumeric);
+  const cefr = useCareerStore((s) => s.cefr) || 'B1';
+
+  const uiLang = useUiStore((s) => s.uiLang);
+  const targetLang = useUiStore((s) => s.targetLang);
+
+  const fetchWord = useCallback(async () => {
+    const res = await fetch('/api/ai/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        targetLang,
+        cefr,
+        uiLanguage: uiLang,
+      }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setWordItem(data);
+    }
+  }, [targetLang, cefr, uiLang, setWordItem]);
+
+  useEffect(() => {
+    fetchWord();
+  }, [fetchWord]);
 
   const mask = buildMask(word, revealed);
 
@@ -26,12 +56,30 @@ export default function GameBoard({ word, hint }: GameBoardProps) {
     if (makeGuess(guess)) {
       const xp = calcXpGain(level, points);
       awardXP(xp);
-      alert(`Correct! +${xp} XP`);
+      setShowResult(true);
     } else {
-      alert('Try again');
+      setShake(true);
+      setTimeout(() => setShake(false), 300);
     }
     setGuess('');
   };
+
+  const handleNext = () => {
+    setShowResult(false);
+    fetchWord();
+  };
+
+  if (!word) return <p>Loading...</p>;
+
+  if (showResult)
+    return (
+      <WordResultCard
+        word={word}
+        example={example}
+        translation={translation}
+        onNext={handleNext}
+      />
+    );
 
   return (
     <div className="space-y-4">
@@ -39,8 +87,11 @@ export default function GameBoard({ word, hint }: GameBoardProps) {
       <p className="text-lg">Hint: {hint}</p>
       <p className="text-2xl tracking-widest">{mask}</p>
       <div className="flex gap-2">
-        <Button variant="secondary" onClick={takeLetter}>Letter</Button>
+        <Button variant="secondary" onClick={takeLetter}>
+          Letter
+        </Button>
         <Input
+          className={cn(shake && 'shake')}
           value={guess}
           onChange={(e) => setGuess(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && handleGuess()}
@@ -50,6 +101,17 @@ export default function GameBoard({ word, hint }: GameBoardProps) {
         <Button onClick={handleGuess}>Guess</Button>
       </div>
       <p>Points: {points}</p>
+      <style jsx>{`
+        @keyframes shake {
+          0%, 100% { transform: translateX(0); }
+          25% { transform: translateX(-4px); }
+          75% { transform: translateX(4px); }
+        }
+        .shake {
+          animation: shake 0.3s;
+        }
+      `}</style>
     </div>
   );
 }
+

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { cefrToNumeric, requiredXP, CEFR, LevelNumeric } from './levels';
 import { calcPoints, revealRandomLetter } from './scoring';
+import { diacriticInsensitiveEquals } from './utils';
 
 export interface UIState {
   uiLang: string;
@@ -91,7 +92,7 @@ export const useGameStore = create<GameState & GameActions>()(
           };
         }),
       makeGuess: (guess) =>
-        guess.trim().toLowerCase() === get().word.toLowerCase(),
+        diacriticInsensitiveEquals(guess, get().word),
       reset: () =>
         set({
           word: '',

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { diacriticInsensitiveEquals } from './utils';
+
+describe('diacriticInsensitiveEquals', () => {
+  it('matches regardless of diacritics and case', () => {
+    expect(diacriticInsensitiveEquals('café', 'CAFE')).toBe(true);
+    expect(diacriticInsensitiveEquals('mañana', 'manana')).toBe(true);
+  });
+
+  it('fails when words differ', () => {
+    expect(diacriticInsensitiveEquals('cafe', 'tea')).toBe(false);
+  });
+});
+

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,15 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+function normalize(str: string): string {
+  return str
+    .normalize('NFD')
+    .replace(/\p{M}/gu, '')
+    .trim()
+    .toLowerCase();
+}
+
+export function diacriticInsensitiveEquals(a: string, b: string): boolean {
+  return normalize(a) === normalize(b);
+}


### PR DESCRIPTION
## Summary
- Fetch new word items from `/api/ai/generate` on game board mount and after correct guesses, wiring into Zustand stores
- Award XP on correct guesses and show a result card; wrong guesses shake the input for feedback
- Add diacritic-insensitive word comparison helper and unit tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689267e587e88327bc7eb3478a95b731