### PR TITLE
feat: add ui polish and animations

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import Footer from '@/components/Footer';
 import Providers from '@/components/Providers';
 import initTranslations from '@/lib/i18n';
 import I18nProvider from '@/components/I18nProvider';
+import PageTransition from '@/components/PageTransition';
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -36,7 +37,9 @@ export default async function RootLayout({
         <I18nProvider locale="en" namespaces={namespaces} resources={resources}>
           <Providers>
             <Header />
-            <main className="p-4 min-h-screen">{children}</main>
+            <main className="p-4 min-h-screen">
+              <PageTransition>{children}</PageTransition>
+            </main>
             <Footer />
           </Providers>
         </I18nProvider>

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -7,7 +7,9 @@ import LevelProgress from './LevelProgress';
 import WordResultCard from './WordResultCard';
 import { useGameStore, useCareerStore, useUiStore } from '@/lib/store';
 import { buildMask, calcXpGain } from '@/lib/scoring';
-import { cn } from '@/lib/utils';
+import { motion } from 'framer-motion';
+
+const MotionInput = motion(Input);
 
 export default function GameBoard() {
   const [guess, setGuess] = useState('');
@@ -60,7 +62,6 @@ export default function GameBoard() {
       setShowResult(true);
     } else {
       setShake(true);
-      setTimeout(() => setShake(false), 300);
     }
     setGuess('');
   };
@@ -85,37 +86,41 @@ export default function GameBoard() {
     );
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       <LevelProgress />
       <p className="text-lg">{t('hint')}: {hint}</p>
       <p className="text-2xl tracking-widest">{mask}</p>
       <div className="flex gap-2">
-        <Button variant="secondary" onClick={takeLetter}>
+        <Button
+          variant="secondary"
+          onClick={takeLetter}
+          aria-label={t('letter')}
+          className="focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
+        >
           {t('letter')}
         </Button>
-        <Input
-          className={cn(shake && 'shake')}
+        <MotionInput
+          className="focus:outline-none focus:ring-2 focus:ring-primary"
           value={guess}
           onChange={(e) => setGuess(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && handleGuess()}
           placeholder={t('guessPlaceholder')}
           aria-label={t('guess')}
+          animate={shake ? { x: [-5, 5, -5, 5, 0] } : { x: 0 }}
+          transition={{ duration: 0.4 }}
+          onAnimationComplete={() => setShake(false)}
         />
-        <Button onClick={handleGuess}>{t('guess')}</Button>
+        <Button
+          onClick={handleGuess}
+          aria-label={t('guess')}
+          className="focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
+        >
+          {t('guess')}
+        </Button>
       </div>
       <p>
         {t('points')}: {points}
       </p>
-      <style jsx>{`
-        @keyframes shake {
-          0%, 100% { transform: translateX(0); }
-          25% { transform: translateX(-4px); }
-          75% { transform: translateX(4px); }
-        }
-        .shake {
-          animation: shake 0.3s;
-        }
-      `}</style>
     </div>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@
 import Link from 'next/link';
 import { useTranslation } from 'next-i18next';
 import { Button } from '@/components/ui/button';
+import ThemeToggle from './ThemeToggle';
 
 export default function Header() {
   const { t } = useTranslation('common');
@@ -10,7 +11,7 @@ export default function Header() {
       <Link href="/" className="text-2xl font-bold">
         {t('title')}
       </Link>
-      <nav className="flex gap-2">
+      <nav className="flex items-center gap-2">
         <Button asChild variant="ghost">
           <Link href="/quick">{t('nav.quick')}</Link>
         </Button>
@@ -23,6 +24,7 @@ export default function Header() {
         <Button asChild variant="ghost">
           <Link href="/settings">{t('nav.settings')}</Link>
         </Button>
+        <ThemeToggle />
       </nav>
     </header>
   );

--- a/src/components/LevelProgress.tsx
+++ b/src/components/LevelProgress.tsx
@@ -1,9 +1,33 @@
 'use client';
+import { useEffect, useRef, useState } from 'react';
 import { useCareerStore } from '@/lib/store';
 import { Progress } from '@/components/ui/progress';
+import ConfettiCelebration from './ConfettiCelebration';
 
 export default function LevelProgress() {
-  const { xp, requiredXp } = useCareerStore();
+  const { xp, requiredXp, levelNumeric } = useCareerStore();
   const value = (xp / requiredXp) * 100;
-  return <Progress value={value} />;
+  const prevLevel = useRef(levelNumeric);
+  const [celebrate, setCelebrate] = useState(false);
+
+  useEffect(() => {
+    if (levelNumeric > prevLevel.current) {
+      setCelebrate(true);
+      prevLevel.current = levelNumeric;
+    }
+  }, [levelNumeric]);
+
+  useEffect(() => {
+    if (celebrate) {
+      const timer = setTimeout(() => setCelebrate(false), 1000);
+      return () => clearTimeout(timer);
+    }
+  }, [celebrate]);
+
+  return (
+    <div className="relative">
+      {celebrate && <ConfettiCelebration />}
+      <Progress value={value} className="h-3 rounded-2xl" />
+    </div>
+  );
 }

--- a/src/components/ModeCards.tsx
+++ b/src/components/ModeCards.tsx
@@ -2,33 +2,42 @@ import Link from 'next/link';
 import { useTranslation } from 'next-i18next';
 import { Card, CardHeader, CardTitle, CardDescription, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { motion } from 'framer-motion';
 
 export default function ModeCards() {
   const { t } = useTranslation('common');
   return (
-    <div className="grid gap-4 md:grid-cols-2">
-      <Card>
-        <CardHeader>
-          <CardTitle>{t('mode.career.title')}</CardTitle>
-          <CardDescription>{t('mode.career.desc')}</CardDescription>
-        </CardHeader>
-        <CardFooter>
-          <Button asChild>
-            <Link href="/career">{t('mode.career.start')}</Link>
-          </Button>
-        </CardFooter>
-      </Card>
-      <Card>
-        <CardHeader>
-          <CardTitle>{t('mode.quick.title')}</CardTitle>
-          <CardDescription>{t('mode.quick.desc')}</CardDescription>
-        </CardHeader>
-        <CardFooter>
-          <Button asChild variant="secondary">
-            <Link href="/quick">{t('mode.quick.start')}</Link>
-          </Button>
-        </CardFooter>
-      </Card>
+    <div className="grid gap-6 sm:grid-cols-2">
+      <motion.div whileHover={{ y: -4 }} className="transition-transform">
+        <Card className="rounded-2xl shadow-md">
+          <CardHeader>
+            <CardTitle>{t('mode.career.title')}</CardTitle>
+            <CardDescription>{t('mode.career.desc')}</CardDescription>
+          </CardHeader>
+          <CardFooter>
+            <Button asChild>
+              <Link href="/career" aria-label={t('mode.career.start')}>
+                {t('mode.career.start')}
+              </Link>
+            </Button>
+          </CardFooter>
+        </Card>
+      </motion.div>
+      <motion.div whileHover={{ y: -4 }} className="transition-transform">
+        <Card className="rounded-2xl shadow-md">
+          <CardHeader>
+            <CardTitle>{t('mode.quick.title')}</CardTitle>
+            <CardDescription>{t('mode.quick.desc')}</CardDescription>
+          </CardHeader>
+          <CardFooter>
+            <Button asChild variant="secondary">
+              <Link href="/quick" aria-label={t('mode.quick.start')}>
+                {t('mode.quick.start')}
+              </Link>
+            </Button>
+          </CardFooter>
+        </Card>
+      </motion.div>
     </div>
   );
 }

--- a/src/components/PageTransition.tsx
+++ b/src/components/PageTransition.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { ReactNode } from 'react';
+import { usePathname } from 'next/navigation';
+import { AnimatePresence, motion } from 'framer-motion';
+
+export default function PageTransition({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  return (
+    <AnimatePresence mode="wait">
+      <motion.div
+        key={pathname}
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -20 }}
+        transition={{ duration: 0.3 }}
+      >
+        {children}
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -9,6 +9,7 @@ import { SessionProvider } from 'next-auth/react';
 export default function Providers({ children }: { children: ReactNode }) {
   const uiLang = useUiStore((s) => s.uiLang);
   const theme = useUiStore((s) => s.theme);
+  const setTheme = useUiStore((s) => s.setTheme);
   const { i18n } = useTranslation();
 
   useEffect(() => {
@@ -18,6 +19,13 @@ export default function Providers({ children }: { children: ReactNode }) {
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
   }, [theme]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && !localStorage.getItem('ui')) {
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      setTheme(prefersDark ? 'dark' : 'light');
+    }
+  }, [setTheme]);
 
   if (process.env.FEATURE_AUTH === 'true') {
     return <SessionProvider>{children}</SessionProvider>;

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useUiStore } from '@/lib/store';
-import { useEffect } from 'react';
+import { Sun, Moon } from 'lucide-react';
 
 export default function ThemeToggle() {
   const theme = useUiStore((s) => s.theme);
@@ -8,13 +8,13 @@ export default function ThemeToggle() {
 
   const toggle = () => setTheme(theme === 'light' ? 'dark' : 'light');
 
-  useEffect(() => {
-    document.documentElement.classList.toggle('dark', theme === 'dark');
-  }, [theme]);
-
   return (
-    <button onClick={toggle} className="px-3 py-1 border rounded">
-      {theme === 'light' ? 'Dark' : 'Light'} Mode
+    <button
+      onClick={toggle}
+      aria-label="Toggle dark mode"
+      className="p-2 rounded-2xl shadow focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
+    >
+      {theme === 'light' ? <Moon className="h-5 w-5" /> : <Sun className="h-5 w-5" />}
     </button>
   );
 }

--- a/src/components/WordResultCard.tsx
+++ b/src/components/WordResultCard.tsx
@@ -10,7 +10,7 @@ export interface WordResultCardProps {
 
 export default function WordResultCard({ word, example, translation, onNext }: WordResultCardProps) {
   return (
-    <Card>
+    <Card className="rounded-2xl shadow-md">
       <CardHeader>
         <CardTitle>{word}</CardTitle>
       </CardHeader>
@@ -19,7 +19,9 @@ export default function WordResultCard({ word, example, translation, onNext }: W
         <p className="text-sm text-muted-foreground">{translation}</p>
       </CardContent>
       <CardFooter className="justify-end">
-        <Button onClick={onNext}>Next</Button>
+        <Button onClick={onNext} aria-label="Next word">
+          Next
+        </Button>
       </CardFooter>
     </Card>
   );


### PR DESCRIPTION
## Summary
- animate page transitions with framer motion
- add dark mode toggle with system preference and a11y polish
- enhance game UI with card hover effects, shake feedback and level-up confetti

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689274c74e88832782b100c88ee8c2a1