### PR TITLE
docs: expand README with setup and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,61 @@
 # BulMaze
 
-Language-learning word game built with Next.js 14, TypeScript and Tailwind CSS.
+Language-learning word game built with Next.js, TypeScript and Tailwind CSS.
 
-## Setup
+## Stack
+- Next.js 15 (App Router)
+- TypeScript
+- Tailwind CSS
+- React Query
+- next-auth (optional)
+- i18next / next-i18next for localization
+
+## Features
+- Quick play mode
+- Career mode with placement wizard and dashboard
+- Profile with game history
+- Settings with language and theme toggles
+- Localization and optional authentication
+
+## Pages
+- `/` – Home / mode selection
+- `/quick` – Quick game board
+- `/career` – Career mode and dashboard
+- `/profile` – User profile overview
+- `/settings` – Language and theme settings
+
+## Environment Setup
+Create `.env.local` based on `.env.local.example` and fill in:
 
 ```bash
-pnpm install
-pnpm dev
+cp .env.local.example .env.local
 ```
 
-Create `.env.local` based on `.env.local.example` for API keys and auth config.
+Key variables:
+- `OPENAI_API_KEY`
+- `FEATURE_AUTH` (set `true` to require login)
+- `NEXTAUTH_SECRET`
+- Provider keys for Google/Apple when auth is enabled
+
+## Scripts
+```bash
+pnpm dev    # start development server
+pnpm build  # create production build
+pnpm start  # run built app
+pnpm lint   # lint with ESLint
+pnpm test   # run tests
+```
+
+## Authentication Toggle
+Set `FEATURE_AUTH=false` (default) to run without login. To enable auth, set `FEATURE_AUTH=true` and configure NextAuth variables (`NEXTAUTH_SECRET`, OAuth provider IDs/secrets).
+
+## Deployment (Vercel)
+- Use `pnpm install` and `pnpm build` for install/build commands
+- Set environment variables from `.env.local`
+- Optionally enable auth via `FEATURE_AUTH`
+- After deployment, `pnpm start` launches the production server
 
 ## Testing
-
 ```bash
 pnpm test
 ```


### PR DESCRIPTION
## Summary
- expand README with stack, features, pages, scripts, and deployment notes

## Testing
- `pnpm lint`
- `pnpm test`
- `OPENAI_API_KEY=dummy pnpm build` *(fails: Failed to collect page data for /_not-found)*
- `OPENAI_API_KEY=dummy pnpm start` *(fails: Could not find a production build in the '.next' directory)*

------
https://chatgpt.com/codex/tasks/task_e_6892bfb5a92883279980fbf8ed0abbbd