### PR TITLE
feat: add central error handling

### DIFF
--- a/src/app/career/loading.tsx
+++ b/src/app/career/loading.tsx
@@ -1,0 +1,9 @@
+import { Loader2 } from 'lucide-react';
+
+export default function Loading() {
+  return (
+    <div className="flex justify-center py-8">
+      <Loader2 className="h-6 w-6 animate-spin" />
+    </div>
+  );
+}

--- a/src/app/quick/loading.tsx
+++ b/src/app/quick/loading.tsx
@@ -1,0 +1,9 @@
+import { Loader2 } from 'lucide-react';
+
+export default function Loading() {
+  return (
+    <div className="flex justify-center py-8">
+      <Loader2 className="h-6 w-6 animate-spin" />
+    </div>
+  );
+}

--- a/src/components/ErrorState.tsx
+++ b/src/components/ErrorState.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+
+interface ErrorStateProps {
+  message?: string;
+  onRetry?: () => void;
+}
+
+export default function ErrorState({ message = 'Something went wrong', onRetry }: ErrorStateProps) {
+  return (
+    <div className="flex flex-col items-center gap-4 py-8">
+      <p>{message}</p>
+      {onRetry && <Button onClick={onRetry}>Retry</Button>}
+    </div>
+  );
+}

--- a/src/components/GameBoard.test.tsx
+++ b/src/components/GameBoard.test.tsx
@@ -47,7 +47,7 @@ vi.mock('@/lib/store', () => ({
 
 vi.stubGlobal(
   'fetch',
-  vi.fn(() => Promise.resolve({ ok: false })),
+  vi.fn(() => Promise.resolve({ ok: false, json: () => Promise.resolve({}) })),
 );
 
 beforeEach(() => {

--- a/src/lib/fetchJson.ts
+++ b/src/lib/fetchJson.ts
@@ -1,0 +1,24 @@
+import { toast } from 'sonner';
+
+export async function fetchJson<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
+  try {
+    const res = await fetch(input, init);
+    if (!res.ok) {
+      let message = 'Request failed';
+      try {
+        const data = await res.json();
+        if (data && typeof data === 'object' && 'error' in data) {
+          message = (data as { error: string }).error;
+        }
+      } catch {
+        // ignore
+      }
+      toast.error(message);
+      throw new Error(message);
+    }
+    return (await res.json()) as T;
+  } catch (err) {
+    toast.error('Network error');
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- centralize API error handling with fetchJson util and reusable ErrorState component
- refactor GameBoard and PlacementWizard to use fetchJson
- add loading states for quick and career routes and adjust tests

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689378970cc08327903a28beab080857