### PR TITLE
feat: harden AI routes with zod validation and retry

### DIFF
--- a/src/app/api/ai/evaluate/route.ts
+++ b/src/app/api/ai/evaluate/route.ts
@@ -6,9 +6,12 @@ const BodySchema = z.object({ answers: z.any() });
 
 export async function POST(req: NextRequest) {
   try {
-    const { answers } = BodySchema.parse(await req.json());
-    const result = await evaluatePlacementAnswers({ answers });
-    return NextResponse.json(result);
+      const { answers } = BodySchema.parse(await req.json());
+      const result = await evaluatePlacementAnswers({ answers });
+      if (!result) {
+        return NextResponse.json({ error: 'Invalid response' }, { status: 422 });
+      }
+      return NextResponse.json(result);
   } catch (err) {
     console.error('Evaluate API error', err);
     return NextResponse.json({ error: 'Server error' }, { status: 500 });

--- a/src/app/api/ai/placement/route.ts
+++ b/src/app/api/ai/placement/route.ts
@@ -1,15 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { generatePlacementTest } from '@/lib/ai';
+import { generatePlacement } from '@/lib/ai';
 import { LangSchema } from '@/lib/schemas';
 
 const BodySchema = z.object({ uiLang: LangSchema });
 
 export async function POST(req: NextRequest) {
   try {
-    const { uiLang } = BodySchema.parse(await req.json());
-    const test = await generatePlacementTest({ uiLang });
-    return NextResponse.json(test);
+      const { uiLang } = BodySchema.parse(await req.json());
+      const test = await generatePlacement({ uiLang });
+      if (!test) {
+        return NextResponse.json({ error: 'Invalid response' }, { status: 422 });
+      }
+      return NextResponse.json(test);
   } catch (err) {
     console.error('Placement API error', err);
     return NextResponse.json({ error: 'Server error' }, { status: 500 });

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -16,28 +16,32 @@ export const WordItemSchema = z.object({
 export type WordItem = z.infer<typeof WordItemSchema>;
 export type Lang = z.infer<typeof LangSchema>;
 
-const PlacementQuestionSchema = z.object({
-  question: z.string(),
+const PlacementItemSchema = z.object({
+  id: z.string(),
+  type: z.enum(['mcq', 'fill']),
+  prompt: z.string(),
   options: z.array(z.string()).optional(),
-  answer: z.string(),
+  correct: z.string().optional(),
 });
 
-export const PlacementTestSchema = z.array(PlacementQuestionSchema).length(10);
+export const PlacementSchema = z.object({
+  items: z.array(PlacementItemSchema).length(10),
+});
 
-export type PlacementTest = z.infer<typeof PlacementTestSchema>;
+export type Placement = z.infer<typeof PlacementSchema>;
 
-export const PlacementResultSchema = z.object({
+export const EvaluateResultSchema = z.object({
   cefr: z.enum(['A1', 'A2', 'B1', 'B2', 'C1', 'C2']),
 });
 
-export type PlacementResult = z.infer<typeof PlacementResultSchema>;
+export type EvaluateResult = z.infer<typeof EvaluateResultSchema>;
 
 const schemas = {
   LangSchema,
   PosSchema,
   WordItemSchema,
-  PlacementTestSchema,
-  PlacementResultSchema,
+  PlacementSchema,
+  EvaluateResultSchema,
 };
 
 export default schemas;

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -112,9 +112,10 @@ export const useGameStore = create<GameState & GameActions>()(
           return value;
         },
       }),
-      migrate: (state: any) => {
-        if (Array.isArray(state?.revealed)) {
-          return { ...state, revealed: new Set<string>(state.revealed) };
+      migrate: (state: unknown) => {
+        const s = state as { revealed?: unknown };
+        if (Array.isArray(s?.revealed)) {
+          return { ...s, revealed: new Set<string>(s.revealed) };
         }
         return state;
       },


### PR DESCRIPTION
## Summary
- add server-only OpenAI client with deterministic retry logic
- validate AI responses with new Zod schemas for word items, placement tests, and evaluations
- return 422 on unparseable AI output and update placement wizard to new format

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894e4159c0c8327af3bfaeda741d59b