### PR TITLE
feat: celebrate with dynamic confetti

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import './globals.css';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import Providers from '@/components/Providers';
+import ConfettiCelebration from '@/components/ConfettiCelebration';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -32,6 +33,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <Providers>
+          <ConfettiCelebration />
           <Header />
           <main className="p-4 min-h-screen">{children}</main>
           <Footer />

--- a/src/components/ConfettiCelebration.tsx
+++ b/src/components/ConfettiCelebration.tsx
@@ -1,17 +1,30 @@
 'use client';
 
 import { useEffect } from 'react';
-import confetti from 'canvas-confetti';
+import type { Options } from 'canvas-confetti';
 
 export default function ConfettiCelebration() {
   useEffect(() => {
-    const fire = () =>
-      confetti({ particleCount: 120, spread: 70, origin: { y: 0.6 } });
+    let confetti: ((options?: Options) => Promise<undefined> | null) | undefined;
+    let cancelled = false;
+
+    import('canvas-confetti').then((mod) => {
+      if (!cancelled) {
+        confetti = mod.default;
+      }
+    });
+
+    const fire = () => {
+      if (confetti) {
+        confetti({ particleCount: 120, spread: 70, origin: { y: 0.6 } });
+      }
+    };
     const win = () => fire();
     const placement = () => fire();
     window.addEventListener('bulmaze:win', win);
     window.addEventListener('bulmaze:placement-finished', placement);
     return () => {
+      cancelled = true;
       window.removeEventListener('bulmaze:win', win);
       window.removeEventListener('bulmaze:placement-finished', placement);
     };

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -5,7 +5,6 @@ import { useEffect } from 'react';
 import { useUiStore } from '@/lib/store';
 import { SessionProvider } from 'next-auth/react';
 import { Toaster } from '@/components/ui/toaster';
-import ConfettiCelebration from './ConfettiCelebration';
 
 export default function Providers({ children }: { children: ReactNode }) {
   const theme = useUiStore((s) => s.theme);
@@ -27,7 +26,6 @@ export default function Providers({ children }: { children: ReactNode }) {
       <SessionProvider>
         {children}
         <Toaster />
-        <ConfettiCelebration />
       </SessionProvider>
     );
   }
@@ -36,7 +34,6 @@ export default function Providers({ children }: { children: ReactNode }) {
     <>
       {children}
       <Toaster />
-      <ConfettiCelebration />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- introduce client-only `ConfettiCelebration` that lazy-loads `canvas-confetti` and fires on custom win and placement events
- render confetti globally from `app/layout.tsx`, keeping html/body hydration warnings suppressed
- streamline `Providers` by removing internal confetti rendering

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894f4c8fda88327bd74adc750eaf6f1