### PR TITLE
Wire i18n and externalize UI strings

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,7 +1,13 @@
+"use client";
+
+import { useTranslation } from 'react-i18next';
+import '@/lib/i18nClient';
+
 export default function Footer() {
+  const { t } = useTranslation('common');
   return (
     <footer className="border-t py-6 text-center text-sm text-muted-foreground">
-      Developed by Mustafa Evleksiz
+      {t('footer.developed')}
     </footer>
   );
 }

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -22,6 +22,8 @@ import { fetchJson } from '@/lib/fetchJson';
 import { toast } from 'sonner';
 import { Loader2 } from 'lucide-react';
 import { motion, useAnimation } from 'framer-motion';
+import { useTranslation } from 'react-i18next';
+import '@/lib/i18nClient';
 
 export default function GameBoard() {
   const [guess, setGuess] = useState('');
@@ -45,6 +47,7 @@ export default function GameBoard() {
 
   const uiLang = useUiStore((s) => s.uiLang);
   const targetLang = useUiStore((s) => s.targetLang);
+  const { t } = useTranslation('game');
 
   const fetchWord = useCallback(async () => {
     setLoading(true);
@@ -65,11 +68,11 @@ export default function GameBoard() {
       setWordItem(data);
     } catch {
       setError(true);
-      toast.error('Failed to fetch word');
+      toast.error(t('fetchError'));
     } finally {
       setLoading(false);
     }
-  }, [targetLang, cefr, uiLang, setWordItem]);
+  }, [targetLang, cefr, uiLang, setWordItem, t]);
 
   useEffect(() => {
     if (!word) {
@@ -98,10 +101,10 @@ export default function GameBoard() {
       window.dispatchEvent(
         new CustomEvent('bulmaze:win', { detail: { leveledUp, xp } }),
       );
-      toast.success('Correct!');
+      toast.success(t('correct'));
       setShowResult(true);
     } else {
-      toast.error('Incorrect guess');
+      toast.error(t('incorrect'));
       void shake.start({
         x: [0, -10, 10, -10, 10, 0],
         transition: { duration: 0.4 },
@@ -144,37 +147,39 @@ export default function GameBoard() {
       className="space-y-6 rounded-2xl p-6 shadow-md"
     >
       <LevelProgress />
-      <p className="text-lg">Hint: {hint}</p>
+      <p className="text-lg">{t('hint')}: {hint}</p>
       <p className="text-2xl tracking-widest">{mask}</p>
       <motion.div animate={shake} className="flex gap-2">
         <Button
           variant="secondary"
           onClick={handleLetter}
-          aria-label="Letter"
+          aria-label={t('letter')}
           disabled={loading}
           className="rounded-2xl shadow-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary"
         >
-          Letter
+          {t('letter')}
         </Button>
         <Input
           className="rounded-2xl shadow-sm focus-visible:ring-2 focus-visible:ring-primary"
           value={guess}
           onChange={(e) => setGuess(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && handleGuess()}
-          placeholder="Your guess"
-          aria-label="Guess"
+          placeholder={t('guessPlaceholder')}
+          aria-label={t('guess')}
           disabled={loading}
         />
         <Button
           onClick={handleGuess}
-          aria-label="Guess"
+          aria-label={t('guess')}
           disabled={loading}
           className="rounded-2xl shadow-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary"
         >
-          Guess
+          {t('guess')}
         </Button>
       </motion.div>
-      <p>Points: {points}</p>
+      <p>
+        {t('points')}: {points}
+      </p>
     </motion.div>
   );
 }

--- a/src/components/ModeCards.tsx
+++ b/src/components/ModeCards.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from 'next/link';
 import {
   Card,
@@ -7,20 +9,23 @@ import {
   CardFooter,
 } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { useTranslation } from 'react-i18next';
+import '@/lib/i18nClient';
 
 export default function ModeCards() {
+  const { t } = useTranslation('common');
   return (
     <div className="grid gap-6 sm:grid-cols-2">
       <div className="transition-transform hover:-translate-y-1">
         <Card className="rounded-2xl shadow-md">
           <CardHeader>
-            <CardTitle>Career Mode</CardTitle>
-            <CardDescription>Progress through levels and earn XP.</CardDescription>
+            <CardTitle>{t('mode.career.title')}</CardTitle>
+            <CardDescription>{t('mode.career.desc')}</CardDescription>
           </CardHeader>
           <CardFooter>
             <Button asChild>
-              <Link href="/career" aria-label="Start">
-                Start
+              <Link href="/career" aria-label={t('mode.career.start')}>
+                {t('mode.career.start')}
               </Link>
             </Button>
           </CardFooter>
@@ -29,13 +34,13 @@ export default function ModeCards() {
       <div className="transition-transform hover:-translate-y-1">
         <Card className="rounded-2xl shadow-md">
           <CardHeader>
-            <CardTitle>Quick Play</CardTitle>
-            <CardDescription>Start a game instantly without login.</CardDescription>
+            <CardTitle>{t('mode.quick.title')}</CardTitle>
+            <CardDescription>{t('mode.quick.desc')}</CardDescription>
           </CardHeader>
           <CardFooter>
             <Button asChild variant="secondary">
-              <Link href="/quick" aria-label="Play">
-                Play
+              <Link href="/quick" aria-label={t('mode.quick.start')}>
+                {t('mode.quick.start')}
               </Link>
             </Button>
           </CardFooter>

--- a/src/components/PlacementWizard.tsx
+++ b/src/components/PlacementWizard.tsx
@@ -17,6 +17,8 @@ import { useUiStore, useCareerStore } from '@/lib/store';
 import { cefrToNumeric, requiredXP, type CEFR } from '@/lib/levels';
 import { fetchJson } from '@/lib/fetchJson';
 import { motion } from 'framer-motion';
+import { useTranslation } from 'react-i18next';
+import '@/lib/i18nClient';
 
 interface Question {
   id: string;
@@ -33,6 +35,7 @@ export default function PlacementWizard() {
   const setLevelNumeric = useCareerStore((s) => s.setLevelNumeric);
   const setRequiredXP = useCareerStore((s) => s.setRequiredXP);
   const router = useRouter();
+  const { t } = useTranslation('career');
 
   const [phase, setPhase] = useState<Phase>('intro');
   const [items, setItems] = useState<Question[]>([]);
@@ -116,13 +119,13 @@ export default function PlacementWizard() {
         className="rounded-2xl shadow-md"
       >
         <CardHeader>
-          <CardTitle>Placement Test</CardTitle>
-          <CardDescription>Start the test to discover your level.</CardDescription>
+          <CardTitle>{t('placement.title')}</CardTitle>
+          <CardDescription>{t('placement.desc')}</CardDescription>
         </CardHeader>
         <CardFooter className="justify-end">
           <Button onClick={start} disabled={loading} className="rounded-2xl shadow-sm">
             {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            {loading ? 'Loading...' : 'Begin test'}
+            {loading ? t('loading') : t('placement.start')}
           </Button>
         </CardFooter>
       </MotionCard>
@@ -139,7 +142,7 @@ export default function PlacementWizard() {
         className="rounded-2xl shadow-md"
       >
         <CardHeader>
-          <CardTitle>Evaluating...</CardTitle>
+          <CardTitle>{t('evaluating')}</CardTitle>
         </CardHeader>
         <CardContent className="flex justify-center">
           <Loader2 className="h-6 w-6 animate-spin" />
@@ -160,7 +163,9 @@ export default function PlacementWizard() {
       className="rounded-2xl shadow-md"
     >
       <CardHeader>
-        <CardTitle>Question {index + 1}</CardTitle>
+        <CardTitle>
+          {t('question')} {index + 1}
+        </CardTitle>
         <CardDescription>{q.prompt}</CardDescription>
       </CardHeader>
       <CardContent>
@@ -183,7 +188,7 @@ export default function PlacementWizard() {
             value={currentAnswer}
             onChange={(e) => recordAnswer(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && currentAnswer && next()}
-            placeholder="Your answer"
+            placeholder={t('answerPlaceholder')}
           />
         )}
       </CardContent>
@@ -196,7 +201,7 @@ export default function PlacementWizard() {
           {submitting && index === items.length - 1 && (
             <Loader2 className="mr-2 h-4 w-4 animate-spin" />
           )}
-          {index === items.length - 1 ? 'Submit' : 'Next'}
+          {index === items.length - 1 ? t('submit') : t('next')}
         </Button>
       </CardFooter>
     </MotionCard>

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -5,14 +5,22 @@ import { useEffect } from 'react';
 import { useUiStore } from '@/lib/store';
 import { SessionProvider } from 'next-auth/react';
 import { Toaster } from '@/components/ui/toaster';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '@/lib/i18nClient';
 
 export default function Providers({ children }: { children: ReactNode }) {
   const theme = useUiStore((s) => s.theme);
   const setTheme = useUiStore((s) => s.setTheme);
+  const uiLang = useUiStore((s) => s.uiLang);
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
   }, [theme]);
+
+  useEffect(() => {
+    void i18n.changeLanguage(uiLang);
+    document.documentElement.lang = uiLang;
+  }, [uiLang]);
 
   useEffect(() => {
     if (typeof window !== 'undefined' && !localStorage.getItem('ui')) {
@@ -24,16 +32,18 @@ export default function Providers({ children }: { children: ReactNode }) {
   if (process.env.FEATURE_AUTH === 'true') {
     return (
       <SessionProvider>
-        {children}
-        <Toaster />
+        <I18nextProvider i18n={i18n}>
+          {children}
+          <Toaster />
+        </I18nextProvider>
       </SessionProvider>
     );
   }
 
   return (
-    <>
+    <I18nextProvider i18n={i18n}>
       {children}
       <Toaster />
-    </>
+    </I18nextProvider>
   );
 }

--- a/src/lib/i18nClient.ts
+++ b/src/lib/i18nClient.ts
@@ -1,0 +1,48 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import nextI18NextConfig from '../../next-i18next.config.mjs';
+
+import enCommon from '../locales/en/common.json';
+import enGame from '../locales/en/game.json';
+import enCareer from '../locales/en/career.json';
+
+import trCommon from '../locales/tr/common.json';
+import trGame from '../locales/tr/game.json';
+import trCareer from '../locales/tr/career.json';
+
+import deCommon from '../locales/de/common.json';
+import deGame from '../locales/de/game.json';
+import deCareer from '../locales/de/career.json';
+
+import esCommon from '../locales/es/common.json';
+import esGame from '../locales/es/game.json';
+import esCareer from '../locales/es/career.json';
+
+import itCommon from '../locales/it/common.json';
+import itGame from '../locales/it/game.json';
+import itCareer from '../locales/it/career.json';
+
+import ptCommon from '../locales/pt/common.json';
+import ptGame from '../locales/pt/game.json';
+import ptCareer from '../locales/pt/career.json';
+
+const resources = {
+  en: { common: enCommon, game: enGame, career: enCareer },
+  tr: { common: trCommon, game: trGame, career: trCareer },
+  de: { common: deCommon, game: deGame, career: deCareer },
+  es: { common: esCommon, game: esGame, career: esCareer },
+  it: { common: itCommon, game: itGame, career: itCareer },
+  pt: { common: ptCommon, game: ptGame, career: ptCareer },
+};
+
+if (!i18n.isInitialized) {
+  i18n.use(initReactI18next).init({
+    resources,
+    ...nextI18NextConfig,
+    lng: 'en',
+    interpolation: { escapeValue: false },
+  });
+}
+
+export default i18n;
+

--- a/src/locales/de/career.json
+++ b/src/locales/de/career.json
@@ -5,6 +5,7 @@
     "start": "Test starten"
   },
   "loading": "Lädt...",
+  "evaluating": "Wird bewertet...",
   "question": "Frage",
   "answerPlaceholder": "Deine Antwort",
   "submit": "Absenden",

--- a/src/locales/de/game.json
+++ b/src/locales/de/game.json
@@ -4,5 +4,8 @@
   "letter": "Buchstabe",
   "guessPlaceholder": "Dein Tipp",
   "guess": "Raten",
-  "points": "Punkte"
+  "points": "Punkte",
+  "fetchError": "Wort konnte nicht geladen werden",
+  "correct": "Richtig!",
+  "incorrect": "Falscher Tipp"
 }

--- a/src/locales/en/career.json
+++ b/src/locales/en/career.json
@@ -5,6 +5,7 @@
     "start": "Start Test"
   },
   "loading": "Loading...",
+  "evaluating": "Evaluating...",
   "question": "Question",
   "answerPlaceholder": "Your answer",
   "submit": "Submit",

--- a/src/locales/en/game.json
+++ b/src/locales/en/game.json
@@ -4,5 +4,8 @@
   "letter": "Letter",
   "guessPlaceholder": "Your guess",
   "guess": "Guess",
-  "points": "Points"
+  "points": "Points",
+  "fetchError": "Failed to fetch word",
+  "correct": "Correct!",
+  "incorrect": "Incorrect guess"
 }

--- a/src/locales/es/career.json
+++ b/src/locales/es/career.json
@@ -5,6 +5,7 @@
     "start": "Iniciar Prueba"
   },
   "loading": "Cargando...",
+  "evaluating": "Evaluando...",
   "question": "Pregunta",
   "answerPlaceholder": "Tu respuesta",
   "submit": "Enviar",

--- a/src/locales/es/game.json
+++ b/src/locales/es/game.json
@@ -4,5 +4,8 @@
   "letter": "Letra",
   "guessPlaceholder": "Tu respuesta",
   "guess": "Adivinar",
-  "points": "Puntos"
+  "points": "Puntos",
+  "fetchError": "No se pudo obtener la palabra",
+  "correct": "¡Correcto!",
+  "incorrect": "Respuesta incorrecta"
 }

--- a/src/locales/it/career.json
+++ b/src/locales/it/career.json
@@ -5,6 +5,7 @@
     "start": "Inizia Test"
   },
   "loading": "Caricamento...",
+  "evaluating": "Valutazione in corso...",
   "question": "Domanda",
   "answerPlaceholder": "La tua risposta",
   "submit": "Invia",

--- a/src/locales/it/game.json
+++ b/src/locales/it/game.json
@@ -4,5 +4,8 @@
   "letter": "Lettera",
   "guessPlaceholder": "La tua risposta",
   "guess": "Indovina",
-  "points": "Punti"
+  "points": "Punti",
+  "fetchError": "Impossibile recuperare la parola",
+  "correct": "Corretto!",
+  "incorrect": "Risposta errata"
 }

--- a/src/locales/pt/career.json
+++ b/src/locales/pt/career.json
@@ -5,6 +5,7 @@
     "start": "Iniciar Teste"
   },
   "loading": "Carregando...",
+  "evaluating": "Avaliando...",
   "question": "Pergunta",
   "answerPlaceholder": "Sua resposta",
   "submit": "Enviar",

--- a/src/locales/pt/game.json
+++ b/src/locales/pt/game.json
@@ -4,5 +4,8 @@
   "letter": "Letra",
   "guessPlaceholder": "Seu palpite",
   "guess": "Adivinhar",
-  "points": "Pontos"
+  "points": "Pontos",
+  "fetchError": "Falha ao buscar palavra",
+  "correct": "Correto!",
+  "incorrect": "Palpite incorreto"
 }

--- a/src/locales/tr/career.json
+++ b/src/locales/tr/career.json
@@ -5,6 +5,7 @@
     "start": "Testi Başlat"
   },
   "loading": "Yükleniyor...",
+  "evaluating": "Değerlendiriliyor...",
   "question": "Soru",
   "answerPlaceholder": "Cevabın",
   "submit": "Gönder",

--- a/src/locales/tr/game.json
+++ b/src/locales/tr/game.json
@@ -4,5 +4,8 @@
   "letter": "Harf",
   "guessPlaceholder": "Tahminin",
   "guess": "Tahmin et",
-  "points": "Puan"
+  "points": "Puan",
+  "fetchError": "Kelime alınamadı",
+  "correct": "Doğru!",
+  "incorrect": "Yanlış tahmin"
 }


### PR DESCRIPTION
## Summary
- integrate i18next provider and language switching
- move GameBoard, PlacementWizard, ModeCards and Footer text to translations
- add translation keys for game and career flows across six locales

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894f8134fc0832783867e70ea5827b1