### PR TITLE
Add coverage for quick, career, and celebration flows

### DIFF
--- a/src/components/ConfettiCelebration.test.tsx
+++ b/src/components/ConfettiCelebration.test.tsx
@@ -1,0 +1,20 @@
+import { render, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import ConfettiCelebration from './ConfettiCelebration';
+
+const mockConfetti = vi.fn();
+vi.mock('canvas-confetti', () => ({ default: mockConfetti }));
+
+describe('ConfettiCelebration', () => {
+  it('fires confetti on game win and placement finish', async () => {
+    render(<ConfettiCelebration />);
+    // wait for dynamic import to resolve
+    await new Promise((r) => setTimeout(r, 0));
+    window.dispatchEvent(new Event('bulmaze:win'));
+    window.dispatchEvent(new Event('bulmaze:placement-finished'));
+    await waitFor(() => {
+      expect(mockConfetti).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/components/ConfettiCelebration.tsx
+++ b/src/components/ConfettiCelebration.tsx
@@ -1,15 +1,20 @@
 'use client';
 
 import { useEffect } from 'react';
+import type { Options } from 'canvas-confetti';
+// eslint-disable-next-line no-unused-vars
+type ConfettiFn = (options: Options) => void;
 
 export default function ConfettiCelebration() {
   useEffect(() => {
-    let confetti: typeof import('canvas-confetti').default | undefined;
+    let confetti: ConfettiFn | undefined;
     let cancelled = false;
 
-    import('canvas-confetti').then((mod) => {
+    import('canvas-confetti').then((mod: unknown) => {
       if (!cancelled) {
-        confetti = mod.default;
+        const fn =
+          (mod as { default?: ConfettiFn }).default ?? (mod as ConfettiFn);
+        confetti = fn;
       }
     });
 

--- a/src/components/GameBoard.test.tsx
+++ b/src/components/GameBoard.test.tsx
@@ -16,32 +16,43 @@ vi.mock('@/components/WordResultCard', () => ({
   ),
 }));
 
-const mockGameState = {
-  word: 'test',
-  hint: 'clue',
-  example: 'ex',
-  exampleTranslation: 'ex t',
-  revealed: new Set(['t']),
-  points: 80,
-  setWordItem: vi.fn(),
-  reset: vi.fn(),
-};
-
-const mockCareerState = {
-  awardXP: vi.fn(),
-  levelNumeric: 2,
-  cefr: 'A2',
-};
-
-const mockUiState = {
-  uiLang: 'en',
-  targetLang: 'en',
-};
+const {
+  mockGameState,
+  mockCareerState,
+  mockUiState,
+  mockSetState,
+} = vi.hoisted(() => {
+  const mockGameState = {
+    word: 'test',
+    hint: 'clue',
+    example: 'ex',
+    exampleTranslation: 'ex t',
+    revealed: new Set(['t']),
+    points: 80,
+    lettersTaken: 2,
+    setWordItem: vi.fn(),
+    reset: vi.fn(),
+  };
+  const mockCareerState = {
+    awardXP: vi.fn(),
+    levelNumeric: 2,
+    cefr: 'A2',
+  };
+  const mockUiState = {
+    uiLang: 'en',
+    targetLang: 'en',
+  };
+  const mockSetState = vi.fn((fn: any) => {
+    const result = typeof fn === 'function' ? fn(mockGameState) : fn;
+    Object.assign(mockGameState, result);
+  });
+  return { mockGameState, mockCareerState, mockUiState, mockSetState };
+});
 
 vi.mock('@/lib/store', () => ({
   useGameStore: Object.assign(
     (selector: any) => selector(mockGameState),
-    { setState: vi.fn() }
+    { setState: mockSetState }
   ),
   useCareerStore: (selector: any) => selector(mockCareerState),
   useUiStore: (selector: any) => selector(mockUiState),
@@ -57,11 +68,21 @@ vi.stubGlobal(
 );
 
 beforeEach(() => {
+  mockGameState.word = 'test';
+  mockGameState.hint = 'clue';
+  mockGameState.example = 'ex';
+  mockGameState.exampleTranslation = 'ex t';
+  mockGameState.revealed = new Set(['t']);
+  mockGameState.points = 80;
+  mockGameState.lettersTaken = 2;
+  mockGameState.setWordItem.mockReset();
+  mockGameState.reset.mockReset();
+  mockCareerState.awardXP.mockReset();
   vi.clearAllMocks();
 });
 
 describe('GameBoard', () => {
-  it('shows result and fetches next word on next', async () => {
+  it('shows result, resets and fetches next word on next', async () => {
     render(<GameBoard />);
     const input = screen.getAllByPlaceholderText('Your guess')[0];
     fireEvent.change(input, { target: { value: 'test' } });
@@ -73,6 +94,18 @@ describe('GameBoard', () => {
 
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledTimes(1);
+      expect(mockGameState.reset).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it('reduces points to 90 when taking a letter', () => {
+    mockGameState.revealed = new Set();
+    mockGameState.points = 100;
+    mockGameState.lettersTaken = 0;
+    render(<GameBoard />);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Letter' })[0]);
+
+    expect(mockGameState.points).toBe(90);
+    expect(mockGameState.lettersTaken).toBe(1);
   });
 });

--- a/src/components/PlacementWizard.test.tsx
+++ b/src/components/PlacementWizard.test.tsx
@@ -1,0 +1,77 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+
+const { mockSetCEFR, mockCareerState, mockUiState } = vi.hoisted(() => {
+  const mockSetCEFR = vi.fn();
+  const mockCareerState = {
+    setCEFR: mockSetCEFR,
+    setLevelNumeric: vi.fn(),
+    setRequiredXP: vi.fn(),
+  };
+  const mockUiState = { uiLang: 'en' };
+  return { mockSetCEFR, mockCareerState, mockUiState };
+});
+
+vi.mock('@/lib/store', () => ({
+  useCareerStore: (selector: any) => selector(mockCareerState),
+  useUiStore: (selector: any) => selector(mockUiState),
+}));
+
+const { mockRouter } = vi.hoisted(() => ({ mockRouter: { push: vi.fn() } }));
+vi.mock('next/navigation', () => ({ useRouter: () => mockRouter }));
+
+const { mockPostJSON } = vi.hoisted(() => {
+  const placementItems = Array.from({ length: 12 }, (_, i) => ({
+    id: String(i),
+    type: 'fill' as const,
+    prompt: `p${i}`,
+  }));
+  const mockPostJSON = vi.fn((url: string) => {
+    if (url === '/api/ai/placement') {
+      return Promise.resolve({ items: placementItems });
+    }
+    if (url === '/api/ai/evaluate') {
+      return Promise.resolve({ cefr: 'B2' });
+    }
+    return Promise.resolve({});
+  });
+  return { mockPostJSON };
+});
+
+vi.mock('@/lib/postJson', () => ({ postJSON: mockPostJSON }));
+
+const PlacementWizard = (await import('./PlacementWizard')).default;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+});
+
+describe('PlacementWizard', () => {
+  it('runs placement and redirects with celebration', async () => {
+    render(<PlacementWizard />);
+
+    fireEvent.click(await screen.findByText('Start Test'));
+    await screen.findByText('Question 1');
+
+    for (let i = 1; i < 10; i += 1) {
+      const input = screen.getByPlaceholderText('Your answer');
+      fireEvent.change(input, { target: { value: `ans${i}` } });
+      fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+      await screen.findByText(`Question ${i + 1}`);
+    }
+
+    const input = screen.getByPlaceholderText('Your answer');
+    fireEvent.change(input, { target: { value: 'final' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(mockPostJSON).toHaveBeenCalledTimes(2);
+      expect(mockSetCEFR).toHaveBeenCalledWith('B2');
+      expect(mockRouter.push).toHaveBeenCalledWith('/career?celebrate=1#dashboard');
+      expect(window.localStorage.getItem('placementDone')).toBe('1');
+    });
+  });
+});

--- a/src/components/PlacementWizard.tsx
+++ b/src/components/PlacementWizard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import React, { useState } from 'react';
 import {
   Card,
   CardHeader,


### PR DESCRIPTION
## Summary
- test quick mode scoring and next-word reset
- exercise career placement flow and redirect logic
- ensure confetti fires on win or placement completion

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689506df0e248327b11c71122260f2c5