### PR TITLE
feat: make auth optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ pnpm test   # run tests
 ```
 
 ## Authentication Toggle
-Set `FEATURE_AUTH=false` (default) to run without login. To enable auth, set `FEATURE_AUTH=true` and configure NextAuth variables (`NEXTAUTH_SECRET`, OAuth provider IDs/secrets).
+Set `FEATURE_AUTH=false` (default) to run without login; career progress is stored in localStorage.
+To enable authentication, set `FEATURE_AUTH=true` and provide `NEXTAUTH_SECRET` along with Google and Apple OAuth keys.
+When enabled, users must sign in and their career progress is saved via `/api/profile` using NextAuth.
 
 ## Deployment (Vercel)
 - Use `pnpm install` and `pnpm build` for install/build commands

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -2,15 +2,20 @@ import { type NextAuthOptions } from 'next-auth';
 import GoogleProvider from 'next-auth/providers/google';
 import AppleProvider from 'next-auth/providers/apple';
 
+const providers =
+  process.env.FEATURE_AUTH === 'true'
+    ? [
+        GoogleProvider({
+          clientId: process.env.GOOGLE_CLIENT_ID!,
+          clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+        }),
+        AppleProvider({
+          clientId: process.env.APPLE_CLIENT_ID!,
+          clientSecret: process.env.APPLE_CLIENT_SECRET!,
+        }),
+      ]
+    : [];
+
 export const authOptions: NextAuthOptions = {
-  providers: [
-    GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID!,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
-    }),
-    AppleProvider({
-      clientId: process.env.APPLE_CLIENT_ID!,
-      clientSecret: process.env.APPLE_CLIENT_SECRET!,
-    }),
-  ],
+  providers,
 };


### PR DESCRIPTION
## Summary
- conditionally register Google and Apple providers when `FEATURE_AUTH=true`
- document authentication toggle and profile persistence

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68950b4581ac8327b325378e32fbf2fa