### PR TITLE
feat: add framer-motion animations

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import Providers from '@/components/Providers';
 import ConfettiCelebration from '@/components/ConfettiCelebration';
+import PageTransition from '@/components/PageTransition';
 
 const geistSans = Geist({ subsets: ['latin'] });
 const geistMono = Geist_Mono({ subsets: ['latin'] });
@@ -28,7 +29,9 @@ export default function RootLayout({
         <Providers>
           <ConfettiCelebration />
           <Header />
-          <main className="container mx-auto p-4 min-h-screen">{children}</main>
+          <PageTransition>
+            <main className="container mx-auto p-4 min-h-screen">{children}</main>
+          </PageTransition>
           <Footer />
         </Providers>
       </body>

--- a/src/components/ModeCards.tsx
+++ b/src/components/ModeCards.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from 'next/link';
+import { motion } from 'framer-motion';
 import {
   Card,
   CardHeader,
@@ -16,7 +17,12 @@ export default function ModeCards() {
   const { t } = useTranslation('common');
   return (
     <div className="grid gap-6 sm:grid-cols-2">
-      <div className="transition-transform hover:-translate-y-1">
+      <motion.div
+        whileHover={{ y: -5 }}
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3 }}
+      >
         <Card className="rounded-2xl shadow-md">
           <CardHeader>
             <CardTitle>{t('mode.career.title')}</CardTitle>
@@ -30,8 +36,13 @@ export default function ModeCards() {
             </Button>
           </CardFooter>
         </Card>
-      </div>
-      <div className="transition-transform hover:-translate-y-1">
+      </motion.div>
+      <motion.div
+        whileHover={{ y: -5 }}
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3, delay: 0.1 }}
+      >
         <Card className="rounded-2xl shadow-md">
           <CardHeader>
             <CardTitle>{t('mode.quick.title')}</CardTitle>
@@ -45,7 +56,7 @@ export default function ModeCards() {
             </Button>
           </CardFooter>
         </Card>
-      </div>
+      </motion.div>
     </div>
   );
 }

--- a/src/components/PageTransition.tsx
+++ b/src/components/PageTransition.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { AnimatePresence, motion } from 'framer-motion';
+import { usePathname } from 'next/navigation';
+
+export default function PageTransition({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  return (
+    <AnimatePresence mode="wait">
+      <motion.div
+        key={pathname}
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -10 }}
+        transition={{ duration: 0.2 }}
+      >
+        {children}
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/src/components/QuickGame.tsx
+++ b/src/components/QuickGame.tsx
@@ -2,7 +2,7 @@
 // QuickGame modern React component
 
 import { useState, useReducer } from 'react';
-import { motion } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
 import { CheckCircle, XCircle } from 'lucide-react';
 
 export type Question = {
@@ -92,49 +92,62 @@ export default function QuickGame({ questions = sampleQuestions }: QuickGameProp
   return (
     <div className="max-w-md mx-auto p-6 space-y-4">
       <div className="text-right text-sm text-gray-500">Score: {state.score}</div>
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={currentQuestion.id}
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -20 }}
+          transition={{ duration: 0.3 }}
+          className="bg-white shadow-lg rounded-lg p-6 space-y-6"
+        >
+          <h2 className="text-xl font-medium">{currentQuestion.question}</h2>
+          <div className="grid grid-cols-1 gap-4">
+            {currentQuestion.options.map((opt) => {
+              const isCorrect = status !== 'idle' && opt === currentQuestion.answer;
+              const isWrong = status === 'wrong' && selected === opt;
 
-      <div className="bg-white shadow-lg rounded-lg p-6 space-y-6">
-        <h2 className="text-xl font-medium">{currentQuestion.question}</h2>
-        <div className="grid grid-cols-1 gap-4">
-          {currentQuestion.options.map((opt) => {
-            const isCorrect = status !== 'idle' && opt === currentQuestion.answer;
-            const isWrong = status === 'wrong' && selected === opt;
-
-            return (
-              <button
-                key={opt}
-                onClick={() => handleAnswer(opt)}
-                disabled={status !== 'idle'}
-                className={`relative px-4 py-2 border rounded-md text-left transition-colors shadow
-                  hover:bg-gray-50 focus:outline-none disabled:opacity-75
-                  ${isCorrect ? 'bg-green-100' : ''}
-                  ${isWrong ? 'bg-red-100' : ''}
-                `}
-              >
-                {opt}
-                {isCorrect && (
-                  <motion.span
-                    initial={{ scale: 0 }}
-                    animate={{ scale: 1 }}
-                    className="absolute top-2 right-2 text-green-500"
-                  >
-                    <CheckCircle size={20} />
-                  </motion.span>
-                )}
-                {isWrong && (
-                  <motion.span
-                    initial={{ scale: 0 }}
-                    animate={{ scale: 1 }}
-                    className="absolute top-2 right-2 text-red-500"
-                  >
-                    <XCircle size={20} />
-                  </motion.span>
-                )}
-              </button>
-            );
-          })}
-        </div>
-      </div>
+              return (
+                <motion.button
+                  key={opt}
+                  onClick={() => handleAnswer(opt)}
+                  disabled={status !== 'idle'}
+                  initial={false}
+                  animate={
+                    isCorrect
+                      ? { backgroundColor: '#d1fae5', scale: 1.05 }
+                      : isWrong
+                      ? { backgroundColor: '#fee2e2', x: [0, -8, 8, -8, 8, 0] }
+                      : { backgroundColor: '#ffffff', scale: 1, x: 0 }
+                  }
+                  transition={{ duration: 0.3 }}
+                  className="relative px-4 py-2 border rounded-md text-left shadow hover:bg-gray-50 focus:outline-none disabled:opacity-75"
+                >
+                  {opt}
+                  {isCorrect && (
+                    <motion.span
+                      initial={{ scale: 0 }}
+                      animate={{ scale: 1 }}
+                      className="absolute top-2 right-2 text-green-500"
+                    >
+                      <CheckCircle size={20} />
+                    </motion.span>
+                  )}
+                  {isWrong && (
+                    <motion.span
+                      initial={{ scale: 0 }}
+                      animate={{ scale: 1 }}
+                      className="absolute top-2 right-2 text-red-500"
+                    >
+                      <XCircle size={20} />
+                    </motion.span>
+                  )}
+                </motion.button>
+              );
+            })}
+          </div>
+        </motion.div>
+      </AnimatePresence>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add PageTransition component using framer-motion for page transitions
- animate ModeCards for subtle card movements
- enhance QuickGame with animated question transitions and answer feedback

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895deb1a13c8327b82e4ebc615bee02