### PR TITLE
feat: add game and user context

### DIFF
--- a/src/components/GameStatus.tsx
+++ b/src/components/GameStatus.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+/* Example component consuming the game context. */
+
+import { useGameContext } from '@/context/GameContext';
+
+export default function GameStatus() {
+  const {
+    state: { score, currentQuestion, questions },
+    dispatch,
+  } = useGameContext();
+
+  const current = questions[currentQuestion] ?? 'No question';
+
+  return (
+    <div className="space-y-2">
+      <p>Score: {score}</p>
+      <p>Active question: {current}</p>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          className="rounded bg-blue-500 px-2 py-1 text-white"
+          onClick={() => dispatch({ type: 'ANSWER', points: 10 })}
+        >
+          +10
+        </button>
+        <button
+          type="button"
+          className="rounded bg-gray-500 px-2 py-1 text-white"
+          onClick={() => dispatch({ type: 'NEXT_QUESTION' })}
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -7,6 +7,8 @@ import { SessionProvider } from 'next-auth/react';
 import { Toaster } from '@/components/ui/toaster';
 import { I18nextProvider } from 'react-i18next';
 import i18n from '@/lib/i18nClient';
+import { GameProvider } from '@/context/GameContext';
+import { UserProvider } from '@/context/UserContext';
 
 export default function Providers({ children }: { children: ReactNode }) {
   const theme = useUiStore((s) => s.theme);
@@ -29,21 +31,29 @@ export default function Providers({ children }: { children: ReactNode }) {
     }
   }, [setTheme]);
 
-  if (process.env.FEATURE_AUTH === 'true') {
-    return (
-      <SessionProvider>
-        <I18nextProvider i18n={i18n}>
-          {children}
-          <Toaster />
-        </I18nextProvider>
-      </SessionProvider>
-    );
-  }
+    if (process.env.FEATURE_AUTH === 'true') {
+      return (
+        <SessionProvider>
+          <I18nextProvider i18n={i18n}>
+            <UserProvider>
+              <GameProvider>
+                {children}
+                <Toaster />
+              </GameProvider>
+            </UserProvider>
+          </I18nextProvider>
+        </SessionProvider>
+      );
+    }
 
-  return (
-    <I18nextProvider i18n={i18n}>
-      {children}
-      <Toaster />
-    </I18nextProvider>
-  );
+    return (
+      <I18nextProvider i18n={i18n}>
+        <UserProvider>
+          <GameProvider>
+            {children}
+            <Toaster />
+          </GameProvider>
+        </UserProvider>
+      </I18nextProvider>
+    );
 }

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+/* Global game state managed with React Context and useReducer. */
+
+import { createContext, useContext, useReducer, type ReactNode } from 'react';
+
+interface GameState {
+  score: number;
+  currentQuestion: number;
+  questions: string[];
+}
+
+type GameAction =
+  | { type: 'SET_QUESTIONS'; questions: string[] }
+  | { type: 'ANSWER'; points: number }
+  | { type: 'NEXT_QUESTION' }
+  | { type: 'RESET' };
+
+const initialState: GameState = {
+  score: 0,
+  currentQuestion: 0,
+  questions: [],
+};
+
+function gameReducer(state: GameState, action: GameAction): GameState {
+  switch (action.type) {
+    case 'SET_QUESTIONS':
+      return { score: 0, currentQuestion: 0, questions: action.questions };
+    case 'ANSWER':
+      return { ...state, score: state.score + action.points };
+    case 'NEXT_QUESTION':
+      return { ...state, currentQuestion: state.currentQuestion + 1 };
+    case 'RESET':
+      return initialState;
+    default:
+      return state;
+  }
+}
+
+const GameContext = createContext<{
+  state: GameState;
+  dispatch: React.Dispatch<GameAction>;
+} | undefined>(undefined);
+
+export function GameProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(gameReducer, initialState);
+  return (
+    <GameContext.Provider value={{ state, dispatch }}>
+      {children}
+    </GameContext.Provider>
+  );
+}
+
+export function useGameContext() {
+  const context = useContext(GameContext);
+  if (!context) {
+    throw new Error('useGameContext must be used within GameProvider');
+  }
+  return context;
+}
+

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+/* User information stored with React Context and useReducer. */
+
+import { createContext, useContext, useReducer, type ReactNode } from 'react';
+
+interface UserState {
+  name: string;
+  isLoggedIn: boolean;
+}
+
+type UserAction =
+  | { type: 'LOGIN'; name: string }
+  | { type: 'LOGOUT' };
+
+const initialState: UserState = {
+  name: '',
+  isLoggedIn: false,
+};
+
+function userReducer(state: UserState, action: UserAction): UserState {
+  switch (action.type) {
+    case 'LOGIN':
+      return { name: action.name, isLoggedIn: true };
+    case 'LOGOUT':
+      return initialState;
+    default:
+      return state;
+  }
+}
+
+const UserContext = createContext<{
+  state: UserState;
+  dispatch: React.Dispatch<UserAction>;
+} | undefined>(undefined);
+
+export function UserProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(userReducer, initialState);
+  return (
+    <UserContext.Provider value={{ state, dispatch }}>
+      {children}
+    </UserContext.Provider>
+  );
+}
+
+export function useUserContext() {
+  const context = useContext(UserContext);
+  if (!context) {
+    throw new Error('useUserContext must be used within UserProvider');
+  }
+  return context;
+}
+


### PR DESCRIPTION
## Summary
- add GameContext with reducer-based state for flow, score and active question
- add UserContext to track simple user info
- wrap app with GameProvider and UserProvider and provide example consumer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895e0fae8b08327bf1fdb30ce5a8393