### PR TITLE
Modernize i18n setup and add language switcher demo

### DIFF
--- a/src/components/GameBoard.test.tsx
+++ b/src/components/GameBoard.test.tsx
@@ -84,9 +84,9 @@ beforeEach(() => {
 describe('GameBoard', () => {
   it('shows result, resets and fetches next word on next', async () => {
     render(<GameBoard />);
-    const input = screen.getAllByPlaceholderText('Your guess')[0];
+    const input = (await screen.findAllByPlaceholderText('Your guess'))[0];
     fireEvent.change(input, { target: { value: 'test' } });
-    fireEvent.click(screen.getAllByRole('button', { name: 'Guess' })[0]);
+    fireEvent.click((await screen.findAllByRole('button', { name: 'Guess' }))[0]);
 
     expect(screen.getByTestId('word-result')).toBeDefined();
 
@@ -98,12 +98,12 @@ describe('GameBoard', () => {
     });
   });
 
-  it('reduces points to 90 when taking a letter', () => {
+  it('reduces points to 90 when taking a letter', async () => {
     mockGameState.revealed = new Set();
     mockGameState.points = 100;
     mockGameState.lettersTaken = 0;
     render(<GameBoard />);
-    fireEvent.click(screen.getAllByRole('button', { name: 'Letter' })[0]);
+    fireEvent.click((await screen.findAllByRole('button', { name: 'Letter' }))[0]);
 
     expect(mockGameState.points).toBe(90);
     expect(mockGameState.lettersTaken).toBe(1);

--- a/src/components/LanguageDemo.tsx
+++ b/src/components/LanguageDemo.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+// Demo component: switch between English, Turkish and German using useTranslation
+import { useTranslation } from 'react-i18next';
+import i18n from '@/lib/i18nClient';
+
+export default function LanguageDemo() {
+  const { t } = useTranslation('common');
+
+  return (
+    <div className="flex flex-col items-start gap-2">
+      <p>{t('nav.settings')}</p>
+      <div className="space-x-2">
+        <button onClick={() => void i18n.changeLanguage('en')}>EN</button>
+        <button onClick={() => void i18n.changeLanguage('tr')}>TR</button>
+        <button onClick={() => void i18n.changeLanguage('de')}>DE</button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/i18nClient.ts
+++ b/src/lib/i18nClient.ts
@@ -1,47 +1,22 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
+import resourcesToBackend from 'i18next-resources-to-backend';
 import nextI18NextConfig from '../../next-i18next.config.mjs';
 
-import enCommon from '../locales/en/common.json';
-import enGame from '../locales/en/game.json';
-import enCareer from '../locales/en/career.json';
-
-import trCommon from '../locales/tr/common.json';
-import trGame from '../locales/tr/game.json';
-import trCareer from '../locales/tr/career.json';
-
-import deCommon from '../locales/de/common.json';
-import deGame from '../locales/de/game.json';
-import deCareer from '../locales/de/career.json';
-
-import esCommon from '../locales/es/common.json';
-import esGame from '../locales/es/game.json';
-import esCareer from '../locales/es/career.json';
-
-import itCommon from '../locales/it/common.json';
-import itGame from '../locales/it/game.json';
-import itCareer from '../locales/it/career.json';
-
-import ptCommon from '../locales/pt/common.json';
-import ptGame from '../locales/pt/game.json';
-import ptCareer from '../locales/pt/career.json';
-
-const resources = {
-  en: { common: enCommon, game: enGame, career: enCareer },
-  tr: { common: trCommon, game: trGame, career: trCareer },
-  de: { common: deCommon, game: deGame, career: deCareer },
-  es: { common: esCommon, game: esGame, career: esCareer },
-  it: { common: itCommon, game: itGame, career: itCareer },
-  pt: { common: ptCommon, game: ptGame, career: ptCareer },
-};
-
+// Central i18n instance with lazy-loaded resources from /src/locales
 if (!i18n.isInitialized) {
-  i18n.use(initReactI18next).init({
-    resources,
-    ...nextI18NextConfig,
-    lng: 'en',
-    interpolation: { escapeValue: false },
-  });
+  i18n
+    .use(initReactI18next)
+    .use(
+      resourcesToBackend((lng: string, ns: string) =>
+        import(`../locales/${lng}/${ns}.json`),
+      ),
+    )
+    .init({
+      ...nextI18NextConfig,
+      lng: 'en',
+      interpolation: { escapeValue: false },
+    });
 }
 
 export default i18n;


### PR DESCRIPTION
## Summary
- replace manual imports with dynamic i18n resource loading
- add demo component showing runtime language switching
- adjust tests to await async translations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895e51357e483278dd08b44f357c7d8