### PR TITLE
feat: add BulMaze branding and mockup components

### DIFF
--- a/BRANDING.md
+++ b/BRANDING.md
@@ -1,0 +1,17 @@
+# BulMaze Branding
+
+## Color Palette
+- **Primary:** `#0D9488` – teal
+- **Secondary:** `#F59E0B` – amber
+- **Accent:** `#9333EA` – purple
+- **Background:** `#F8FAFC`
+- **Text:** `#0F172A`
+
+## Logo
+The logo lives at `public/logo.svg` and features a stylized maze forming the letter **B** on a teal square.
+
+## Icons
+Located in `public/icons/`:
+- `brain.svg` – learning and thinking
+- `maze.svg` – puzzle/quick play
+- `trophy.svg` – progress and achievements

--- a/public/icons/brain.svg
+++ b/public/icons/brain.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="#0d9488" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M9 2a4 4 0 0 0-4 4v9a3 3 0 1 0 6 0V4a2 2 0 0 1 2-2"/>
+  <path d="M15 2a4 4 0 0 1 4 4v9a3 3 0 1 1-6 0V4a2 2 0 0 0-2-2"/>
+</svg>

--- a/public/icons/maze.svg
+++ b/public/icons/maze.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="#0d9488" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+  <path d="M3 9h6v6H9M15 3v6h6M15 15v6"/>
+</svg>

--- a/public/icons/trophy.svg
+++ b/public/icons/trophy.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="#0d9488" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M8 21h8M12 17v4"/>
+  <path d="M7 4h10v3a5 5 0 0 1-10 0V4z"/>
+  <path d="M5 4h2v3a5 5 0 0 0 2 4M19 4h-2v3a5 5 0 0 1-2 4"/>
+</svg>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,5 @@
+<svg width="64" height="64" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" rx="20" fill="#0d9488"/>
+  <path d="M30 20h25c11 0 20 9 20 20s-9 20-20 20H30V20z" fill="#f8fafc"/>
+  <path d="M30 60h25c11 0 20 9 20 20s-9 20-20 20H30V60z" fill="#f8fafc"/>
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import 'tailwindcss/tailwind.css';
+import './theme.css';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import Providers from '@/components/Providers';
@@ -24,7 +25,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body
         suppressHydrationWarning
-        className={`${geistSans.className} ${geistMono.className} antialiased bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100`}
+        className={`${geistSans.className} ${geistMono.className} antialiased bg-[var(--bm-bg)] text-[var(--bm-text)]`}
       >
         <Providers>
           <ConfettiCelebration />

--- a/src/app/theme.css
+++ b/src/app/theme.css
@@ -1,0 +1,14 @@
+/* Brand theme variables for BulMaze */
+:root {
+  --bm-primary: #0d9488;
+  --bm-secondary: #f59e0b;
+  --bm-accent: #9333ea;
+  --bm-bg: #f8fafc;
+  --bm-text: #0f172a;
+}
+
+/* Dark theme overrides tied to the `dark` class */
+.dark {
+  --bm-bg: #0f172a;
+  --bm-text: #f8fafc;
+}

--- a/src/components/GamePage.tsx
+++ b/src/components/GamePage.tsx
@@ -1,6 +1,8 @@
+// Game screen mockup applying BulMaze branding.
 'use client';
 
 import { motion } from 'framer-motion';
+import Image from 'next/image';
 import QuickGame from './QuickGame';
 
 export default function GamePage() {
@@ -13,11 +15,12 @@ export default function GamePage() {
       <motion.h2
         initial={{ y: -10, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
-        className="text-3xl sm:text-4xl font-bold mb-8 text-center"
+        className="text-3xl sm:text-4xl font-bold mb-8 text-center text-[var(--bm-primary)] flex items-center gap-2"
       >
+        <Image src="/icons/brain.svg" alt="Brain icon" width={28} height={28} />
         Hızlı Oyun
       </motion.h2>
-      <div className="w-full max-w-xl bg-white dark:bg-gray-800 rounded-xl shadow-xl p-6">
+      <div className="w-full max-w-xl bg-[var(--bm-bg)] dark:bg-gray-800 rounded-xl shadow-xl p-6 border-2 border-[var(--bm-primary)]">
         <QuickGame />
       </div>
     </motion.section>

--- a/src/components/GameScreenMockup.tsx
+++ b/src/components/GameScreenMockup.tsx
@@ -1,0 +1,17 @@
+/** Basic mockup of a BulMaze game screen using brand theme. */
+import Image from 'next/image';
+
+export default function GameScreenMockup() {
+  return (
+    <div className="p-8 bg-[var(--bm-bg)] rounded-xl border-2 border-[var(--bm-primary)] space-y-4 max-w-md mx-auto">
+      <div className="flex items-center justify-center gap-2 text-[var(--bm-primary)]">
+        <Image src="/icons/brain.svg" alt="" width={24} height={24} />
+        <h2 className="text-2xl font-bold">Bulmaca</h2>
+      </div>
+      <div className="h-40 rounded-lg bg-white/50 flex items-center justify-center">
+        <span className="text-gray-500">Oyun Tahtası</span>
+      </div>
+      <button className="w-full px-4 py-2 bg-[var(--bm-accent)] text-white rounded-lg">Tahmin Gönder</button>
+    </div>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,11 +1,14 @@
+// Global application header with BulMaze branding and navigation.
 import Link from 'next/link';
+import Image from 'next/image';
 import { Button } from '@/components/ui/button';
 import ThemeToggle from './ThemeToggle';
 
 export default function Header() {
   return (
-    <header className="flex items-center justify-between p-4 border-b">
-      <Link href="/" className="text-2xl font-bold">
+    <header className="flex items-center justify-between p-4 border-b-2 border-[var(--bm-primary)] bg-[var(--bm-bg)]">
+      <Link href="/" className="flex items-center gap-2 text-2xl font-bold text-[var(--bm-primary)]">
+        <Image src="/logo.svg" alt="BulMaze logo" width={32} height={32} />
         BulMaze
       </Link>
       <nav className="flex items-center gap-2">

--- a/src/components/HomeLanding.tsx
+++ b/src/components/HomeLanding.tsx
@@ -1,18 +1,23 @@
+// Landing section showcasing BulMaze branding on the home page.
 'use client';
 
 import { motion } from 'framer-motion';
 import Link from 'next/link';
+import Image from 'next/image';
 
 export default function HomeLanding() {
   return (
     <section className="flex flex-col items-center justify-center min-h-[70vh] text-center">
-      <motion.h1
+      <motion.div
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
-        className="text-5xl sm:text-6xl font-extrabold bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 bg-clip-text text-transparent"
+        className="flex items-center gap-4"
       >
-        BulMaze
-      </motion.h1>
+        <Image src="/logo.svg" alt="BulMaze logo" width={80} height={80} />
+        <h1 className="text-5xl sm:text-6xl font-extrabold bg-gradient-to-r from-[var(--bm-primary)] to-[var(--bm-secondary)] bg-clip-text text-transparent">
+          BulMaze
+        </h1>
+      </motion.div>
       <motion.p
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
@@ -29,14 +34,16 @@ export default function HomeLanding() {
       >
         <Link
           href="/quick"
-          className="px-6 py-3 rounded-lg shadow-lg bg-indigo-600 hover:bg-indigo-700 text-white transition-colors"
+          className="px-6 py-3 rounded-lg shadow-lg bg-[var(--bm-primary)] hover:bg-teal-700 text-white flex items-center gap-2 transition-colors"
         >
+          <Image src="/icons/maze.svg" alt="Maze icon" width={20} height={20} />
           Hemen Oyna
         </Link>
         <Link
           href="/career"
-          className="px-6 py-3 rounded-lg shadow-lg bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100 transition-colors"
+          className="px-6 py-3 rounded-lg shadow-lg bg-[var(--bm-secondary)] hover:bg-amber-600 text-white flex items-center gap-2 transition-colors"
         >
+          <Image src="/icons/trophy.svg" alt="Trophy icon" width={20} height={20} />
           Kariyer Modu
         </Link>
       </motion.div>

--- a/src/components/HomeMockup.tsx
+++ b/src/components/HomeMockup.tsx
@@ -1,0 +1,21 @@
+/** Basic mockup of the BulMaze home screen using brand theme. */
+import Image from 'next/image';
+
+export default function HomeMockup() {
+  return (
+    <div className="p-8 bg-[var(--bm-bg)] rounded-xl text-center space-y-6">
+      <Image src="/logo.svg" alt="BulMaze logo" width={64} height={64} />
+      <h1 className="text-4xl font-bold text-[var(--bm-primary)]">BulMaze</h1>
+      <div className="flex justify-center gap-4">
+        <button className="px-4 py-2 bg-[var(--bm-primary)] text-white rounded-lg flex items-center gap-2">
+          <Image src="/icons/maze.svg" alt="" width={20} height={20} />
+          Hemen Oyna
+        </button>
+        <button className="px-4 py-2 bg-[var(--bm-secondary)] text-white rounded-lg flex items-center gap-2">
+          <Image src="/icons/trophy.svg" alt="" width={20} height={20} />
+          Kariyer
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/QuickGame.tsx
+++ b/src/components/QuickGame.tsx
@@ -1,5 +1,5 @@
+// QuickGame mini quiz component styled with BulMaze colors.
 'use client';
-// QuickGame modern React component
 
 import { useState, useReducer } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -81,7 +81,7 @@ export default function QuickGame({ questions = sampleQuestions }: QuickGameProp
         </p>
         <button
           onClick={() => dispatch({ type: 'reset' })}
-          className="px-4 py-2 bg-blue-600 text-white rounded-md shadow hover:bg-blue-700 transition-colors"
+          className="px-4 py-2 bg-[var(--bm-primary)] text-white rounded-md shadow hover:bg-teal-700 transition-colors"
         >
           Restart
         </button>
@@ -99,7 +99,7 @@ export default function QuickGame({ questions = sampleQuestions }: QuickGameProp
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: -20 }}
           transition={{ duration: 0.3 }}
-          className="bg-white shadow-lg rounded-lg p-6 space-y-6"
+          className="bg-[var(--bm-bg)] shadow-lg rounded-lg p-6 space-y-6 border-2 border-[var(--bm-primary)]"
         >
           <h2 className="text-xl font-medium">{currentQuestion.question}</h2>
           <div className="grid grid-cols-1 gap-4">


### PR DESCRIPTION
## Summary
- establish BulMaze color variables and logo assets
- style header, home, and game screens with new brand
- add simple mockup components and icon set

## Testing
- `pnpm test`
- `pnpm lint` *(fails: A `require()` style import is forbidden, no-unused-vars, unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_6896006436f0832781e1ef95fc2b3b3d