### PR TITLE
fix: load tailwind from local css

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
-import 'tailwindcss/tailwind.css';
+import './tailwind.css';
 import './theme.css';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';

--- a/src/app/tailwind.css
+++ b/src/app/tailwind.css
@@ -1,0 +1,2 @@
+@import 'tailwindcss';
+


### PR DESCRIPTION
## Summary
- use local Tailwind CSS entrypoint in root layout
- add Tailwind CSS import file

## Testing
- `npm test`
- `npm run lint` *(fails: A `require()` style import is forbidden, variables defined but never used, Unexpected any)*
- `npm run build` *(fails: A `require()` style import is forbidden, variables defined but never used, Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68960ae20bc083279de1394625c19dd2