### PR TITLE
refactor: simplify test motion mocks

### DIFF
--- a/src/components/__tests__/CareerPage.integration.test.tsx
+++ b/src/components/__tests__/CareerPage.integration.test.tsx
@@ -3,23 +3,22 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import CareerPage from '../CareerPage';
 
-jest.mock('framer-motion', () => {
-  const React = require('react');
-  return {
-    AnimatePresence: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-    motion: {
-      div: ({ children, initial, animate, exit, transition, ...props }: any) => (
-        <div {...props}>{children}</div>
-      ),
-      button: ({ children, initial, animate, exit, transition, ...props }: any) => (
-        <button {...props}>{children}</button>
-      ),
-      span: ({ children, initial, animate, exit, transition, ...props }: any) => (
-        <span {...props}>{children}</span>
-      ),
-    },
-  };
-});
+jest.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  motion: {
+    div: ({ children, ...rest }: { children: React.ReactNode } & Record<string, unknown>) => (
+      <div {...rest}>{children}</div>
+    ),
+    button: ({ children, ...rest }: { children: React.ReactNode } & Record<string, unknown>) => (
+      <button {...rest}>{children}</button>
+    ),
+    span: ({ children, ...rest }: { children: React.ReactNode } & Record<string, unknown>) => (
+      <span {...rest}>{children}</span>
+    ),
+  },
+}));
 
 jest.mock('lucide-react', () => ({
   CheckCircle: () => <span data-testid="check" />,

--- a/src/components/__tests__/CareerPage.unit.test.tsx
+++ b/src/components/__tests__/CareerPage.unit.test.tsx
@@ -3,23 +3,22 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import CareerPage from '../CareerPage';
 
-jest.mock('framer-motion', () => {
-  const React = require('react');
-  return {
-    AnimatePresence: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-    motion: {
-      div: ({ children, initial, animate, exit, transition, ...props }: any) => (
-        <div {...props}>{children}</div>
-      ),
-      button: ({ children, initial, animate, exit, transition, ...props }: any) => (
-        <button {...props}>{children}</button>
-      ),
-      span: ({ children, initial, animate, exit, transition, ...props }: any) => (
-        <span {...props}>{children}</span>
-      ),
-    },
-  };
-});
+jest.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  motion: {
+    div: ({ children, ...rest }: { children: React.ReactNode } & Record<string, unknown>) => (
+      <div {...rest}>{children}</div>
+    ),
+    button: ({ children, ...rest }: { children: React.ReactNode } & Record<string, unknown>) => (
+      <button {...rest}>{children}</button>
+    ),
+    span: ({ children, ...rest }: { children: React.ReactNode } & Record<string, unknown>) => (
+      <span {...rest}>{children}</span>
+    ),
+  },
+}));
 
 jest.mock('lucide-react', () => ({
   CheckCircle: () => <span data-testid="check" />,

--- a/src/components/__tests__/QuickGame.integration.test.tsx
+++ b/src/components/__tests__/QuickGame.integration.test.tsx
@@ -3,23 +3,22 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import QuickGame, { Question } from '../QuickGame';
 
-jest.mock('framer-motion', () => {
-  const React = require('react');
-  return {
-    AnimatePresence: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-    motion: {
-      div: ({ children, initial, animate, exit, transition, ...props }: any) => (
-        <div {...props}>{children}</div>
-      ),
-      button: ({ children, initial, animate, exit, transition, ...props }: any) => (
-        <button {...props}>{children}</button>
-      ),
-      span: ({ children, initial, animate, exit, transition, ...props }: any) => (
-        <span {...props}>{children}</span>
-      ),
-    },
-  };
-});
+jest.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  motion: {
+    div: ({ children, ...rest }: { children: React.ReactNode } & Record<string, unknown>) => (
+      <div {...rest}>{children}</div>
+    ),
+    button: ({ children, ...rest }: { children: React.ReactNode } & Record<string, unknown>) => (
+      <button {...rest}>{children}</button>
+    ),
+    span: ({ children, ...rest }: { children: React.ReactNode } & Record<string, unknown>) => (
+      <span {...rest}>{children}</span>
+    ),
+  },
+}));
 
 jest.mock('lucide-react', () => ({
   CheckCircle: () => <span data-testid="check" />,

--- a/src/components/__tests__/QuickGame.unit.test.tsx
+++ b/src/components/__tests__/QuickGame.unit.test.tsx
@@ -3,23 +3,22 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import QuickGame, { Question } from '../QuickGame';
 
-jest.mock('framer-motion', () => {
-  const React = require('react');
-  return {
-    AnimatePresence: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-    motion: {
-      div: ({ children, initial, animate, exit, transition, ...props }: any) => (
-        <div {...props}>{children}</div>
-      ),
-      button: ({ children, initial, animate, exit, transition, ...props }: any) => (
-        <button {...props}>{children}</button>
-      ),
-      span: ({ children, initial, animate, exit, transition, ...props }: any) => (
-        <span {...props}>{children}</span>
-      ),
-    },
-  };
-});
+jest.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  motion: {
+    div: ({ children, ...rest }: { children: React.ReactNode } & Record<string, unknown>) => (
+      <div {...rest}>{children}</div>
+    ),
+    button: ({ children, ...rest }: { children: React.ReactNode } & Record<string, unknown>) => (
+      <button {...rest}>{children}</button>
+    ),
+    span: ({ children, ...rest }: { children: React.ReactNode } & Record<string, unknown>) => (
+      <span {...rest}>{children}</span>
+    ),
+  },
+}));
 
 jest.mock('lucide-react', () => ({
   CheckCircle: () => <span data-testid="check" />,


### PR DESCRIPTION
## Summary
- use type-safe `framer-motion` mocks in tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896136b5bf08327afa1421c3d490948