### PR TITLE
Fix Next.js prerender error on career page

### DIFF
--- a/src/app/career/page.tsx
+++ b/src/app/career/page.tsx
@@ -1,10 +1,5 @@
-import { motion } from 'framer-motion';
 import CareerPage from '@/components/CareerPage';
 
 export default function Page() {
-  return (
-    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
-      <CareerPage />
-    </motion.div>
-  );
+  return <CareerPage />;
 }


### PR DESCRIPTION
## Summary
- remove framer-motion wrapper from /career server page to avoid invalid element during prerender

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689615fdd47c8327b1155eddb587cfda