### PR TITLE
feat: add SM-2 spaced repetition engine

### DIFF
--- a/src/lib/spacedRepetition.test.ts
+++ b/src/lib/spacedRepetition.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { initCard, review, type CardState } from './spacedRepetition';
+
+describe('spaced repetition', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('initCard returns starting values', () => {
+    const card = initCard();
+    expect(card).toEqual({
+      interval: 1,
+      repetition: 0,
+      ease: 2.5,
+      due: new Date('2024-01-01T00:00:00.000Z').toISOString(),
+    });
+  });
+
+  it('review handles failure', () => {
+    const card: CardState = {
+      interval: 10,
+      repetition: 5,
+      ease: 2.5,
+      due: new Date().toISOString(),
+    };
+    const result = review(card, 0);
+    expect(result).toEqual({
+      interval: 1,
+      repetition: 0,
+      ease: 2.3,
+      due: new Date('2024-01-02T00:00:00.000Z').toISOString(),
+    });
+  });
+
+  it('review schedules passes per SM-2', () => {
+    let card = initCard();
+    card = review(card, 5);
+    expect(card).toEqual({
+      interval: 1,
+      repetition: 1,
+      ease: 2.6,
+      due: new Date('2024-01-02T00:00:00.000Z').toISOString(),
+    });
+
+    vi.setSystemTime(new Date('2024-01-02T00:00:00.000Z'));
+    card = review(card, 5);
+    expect(card).toEqual({
+      interval: 6,
+      repetition: 2,
+      ease: 2.7,
+      due: new Date('2024-01-08T00:00:00.000Z').toISOString(),
+    });
+  });
+
+  it('ease never drops below 1.3', () => {
+    const card: CardState = {
+      interval: 5,
+      repetition: 3,
+      ease: 1.35,
+      due: new Date().toISOString(),
+    };
+    const result = review(card, 0);
+    expect(result.ease).toBe(1.3);
+  });
+});

--- a/src/lib/spacedRepetition.ts
+++ b/src/lib/spacedRepetition.ts
@@ -1,0 +1,43 @@
+export type CardState = {
+  interval: number;
+  repetition: number;
+  ease: number;
+  due: string;
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function initCard(): CardState {
+  const now = new Date();
+  return {
+    interval: 1,
+    repetition: 0,
+    ease: 2.5,
+    due: now.toISOString(),
+  };
+}
+
+export function review(card: CardState, quality: 0 | 3 | 4 | 5): CardState {
+  const now = new Date();
+  let { interval, repetition, ease } = card;
+
+  if (quality === 0) {
+    repetition = 0;
+    interval = 1;
+    ease = Math.max(1.3, ease - 0.2);
+  } else {
+    if (repetition === 0) {
+      interval = 1;
+    } else if (repetition === 1) {
+      interval = 6;
+    } else {
+      interval = Math.round(interval * ease);
+    }
+    repetition += 1;
+    const delta = 0.1 - (5 - quality) * (0.08 + (5 - quality) * 0.02);
+    ease = Math.max(1.3, ease + delta);
+  }
+
+  const due = new Date(now.getTime() + interval * DAY_MS).toISOString();
+  return { interval, repetition, ease, due };
+}


### PR DESCRIPTION
## Summary
- implement spaced-repetition engine with SM-2 review algorithm
- add tests for card scheduling and ease adjustments

## Testing
- `npm test`
- `npx vitest run src/lib`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689626c33bf883279a6446ab9deb9f72