### PR TITLE
feat: add seed words loader

### DIFF
--- a/src/lib/seedWords.ts
+++ b/src/lib/seedWords.ts
@@ -1,0 +1,17 @@
+import { useCardsStore, type WordItem } from './store';
+
+const WORDS_URL = 'https://raw.githubusercontent.com/first20hours/google-10000-english/master/20k.txt';
+
+export async function loadSeedWords(): Promise<void> {
+  const response = await fetch(WORDS_URL);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch words: ${response.status} ${response.statusText}`);
+  }
+  const text = await response.text();
+  const words = text.split('\n').map((w) => w.trim()).filter(Boolean).slice(0, 2000);
+  const { addWord } = useCardsStore.getState();
+  for (const word of words) {
+    const placeholder = { word, pos: 'noun', sample: '', level: 'A1' };
+    addWord(placeholder as unknown as WordItem);
+  }
+}


### PR DESCRIPTION
## Summary
- add `loadSeedWords` helper to fetch the first 2000 common English words and seed the cards store

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68963b778ba88327b681f5fbf7a403ec