### PR TITLE
test: add VocabTrainer unit tests

### DIFF
--- a/src/components/__tests__/VocabTrainer.test.tsx
+++ b/src/components/__tests__/VocabTrainer.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import VocabTrainer from '../VocabTrainer';
+import { initCard, review } from '../../lib/spacedRepetition';
+
+jest.mock('zustand', () => ({
+  create: () => () => ({}),
+}));
+
+jest.mock('../../lib/spacedRepetition', () => {
+  const actual = jest.requireActual('../../lib/spacedRepetition');
+  return {
+    ...actual,
+    review: jest.fn(),
+  };
+});
+
+describe('VocabTrainer', () => {
+  it('renders word', () => {
+    const queue = [
+      { id: 1, word: 'ябълка', translation: 'apple', state: initCard() },
+    ];
+    render(<VocabTrainer initialQueue={queue} />);
+    expect(screen.getByText('ябълка')).toBeInTheDocument();
+  });
+
+  it('clicking "Good" calls review() with quality 4', () => {
+    const queue = [
+      { id: 1, word: 'ябълка', translation: 'apple', state: initCard() },
+    ];
+    render(<VocabTrainer initialQueue={queue} />);
+    fireEvent.click(screen.getByText('Good (4)'));
+    expect(review).toHaveBeenCalledWith(queue[0].state, 4);
+  });
+});


### PR DESCRIPTION
## Summary
- add VocabTrainer tests for rendering and review callbacks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68964985616c8327851704380c8afcf6