### PR TITLE
chore: update i18n namespaces

### DIFF
--- a/next-i18next.config.mjs
+++ b/next-i18next.config.mjs
@@ -6,7 +6,7 @@ export default {
     locales: ['en', 'tr', 'de', 'es', 'it', 'pt'],
   },
   defaultNS: 'common',
-  ns: ['common', 'game', 'career'],
+  ns: ['common', 'trainer'],
   fallbackLng: 'en',
   localePath: path.resolve('./src/locales'),
 };


### PR DESCRIPTION
## Summary
- remove unused `game` and `career` namespaces from i18n config
- keep only `common` and `trainer` namespaces

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68964ba3ed2c8327998cf2066a63a233