### PR TITLE
fix: mark Header as client component

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 // Global application header with BulMaze branding and navigation.
 import Link from 'next/link';
 import Image from 'next/image';


### PR DESCRIPTION
## Summary
- designate Header as a Client Component so its use of `useState` works under Next.js

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68965145544c8327b5dea285b04ac1db